### PR TITLE
Version 0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42] - 2025-12-12
+
+### Changed
+- L2 cache test buffer now 10% of reported L2 size (for example targets ~1–2 MB on detected 16MB) to better match observed cache behavior. 
+
 ## [0.41] - 2025-12-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In the Terminal, go to the directory with `memory_benchmark` and use these comma
 
 ## Example output (Mac Mini M4 24GB)
 ```text
------ macOS-memory-benchmark v0.41 -----
+----- macOS-memory-benchmark v0.42 -----
 Program is licensed under GNU GPL v3. See <https://www.gnu.org/licenses/>
 Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
 
@@ -167,7 +167,7 @@ Cache Bandwidth Tests (single-threaded):
 
 Cache Latency Tests (single-threaded, pointer chase):
   L1 Cache: 0.68 ns (Buffer size: 96.00 KB)
-  L2 Cache: 9.64 ns (Buffer size: 12.00 MB)
+  L2 Cache: 4.83 ns (Buffer size: 1.60 MB)
 
 Main Memory Latency Test (single-threaded, pointer chase):
   Total time: 19.797 s

--- a/main.cpp
+++ b/main.cpp
@@ -77,10 +77,9 @@ int main(int argc, char *argv[]) {
   size_t l2_cache_size = get_l2_cache_size();  // Get L2 cache size
 
   // --- Calculate Cache Buffer Sizes ---
-  // Use 75% of cache size to ensure fits within target level
-  const double cache_size_factor = 0.75;
-  size_t l1_buffer_size = static_cast<size_t>(l1_cache_size * cache_size_factor);
-  size_t l2_buffer_size = static_cast<size_t>(l2_cache_size * cache_size_factor);
+  // Use 75% of cache size for L1 and 10% for L2 to ensure fits within target level
+  size_t l1_buffer_size = static_cast<size_t>(l1_cache_size * 0.75);
+  size_t l2_buffer_size = static_cast<size_t>(l2_cache_size * 0.10);
   
   // Ensure buffer sizes are multiples of stride (128 bytes) and at least page size
   size_t page_size_check = getpagesize();

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -37,7 +37,7 @@
 #include <mach/mach_time.h>
 
 // --- Version Information ---
-#define SOFTVERSION 0.41f // Software version
+#define SOFTVERSION 0.42f // Software version
 
 // --- High-resolution timer helper ---
 struct HighResTimer {


### PR DESCRIPTION
L2 cache test buffer now 10% of reported L2 size (for example targets ~1–2 MB on detected 16MB) to better match observed cache behavior. 