### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Unsigned loop termination in latency chase**: Fixed loop branch conditions in `memory_latency_chase_asm` to use counter-based `b.ne` termination, ensuring correct behavior for full `size_t` ranges.
 - **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
 - **`size_t`-safe branch/cleanup fixes across ARM64 bandwidth kernels**: Unified loop/cleanup/byte-tail control flow in forward, reverse, strided, and random read/write/copy kernels to use unsigned or zero/non-zero termination semantics (`b.hs`/`b.lo`/`b.ls`, `cbz`, `b.ne`), and fixed reverse cleanup exit direction plus reverse copy byte-tail pointer initialization for correct full-range behavior.
+- **Mode-aware memory cap validation for `-only-bandwidth` / `-only-latency` / `-patterns`**: Updated `validate_config()` to compute per-buffer limits using the active main-buffer count (1/2/3) instead of always dividing by 3, preventing unnecessary buffer-size capping in reduced-buffer modes while keeping total-memory safeguards intact.
 
 ## [0.52.7] - 2026-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Byte-tail termination in write kernel**: Fixed the `<32B` byte cleanup loop in `memory_write_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
 - **Unsigned loop/cleanup branching in read kernel**: Fixed `memory_read_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
 - **Byte-tail termination in read kernel**: Fixed the `<32B` byte cleanup loop in `memory_read_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
+- **Unsigned loop/cleanup branching in copy kernel**: Fixed `memory_copy_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
+- **Byte-tail termination in copy kernel**: Fixed the `<32B` byte cleanup loop in `memory_copy_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
 
 ## [0.52.7] - 2026-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Zero-access latency chase safety**: Fixed `memory_latency_chase_asm` to return immediately when `count == 0`, preventing an unnecessary dereference when no pointer-chasing accesses are requested.
 - **Unsigned loop termination in latency chase**: Fixed loop branch conditions in `memory_latency_chase_asm` to use counter-based `b.ne` termination, ensuring correct behavior for full `size_t` ranges.
 - **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
-- **Unsigned loop/cleanup branching in write kernel**: Fixed `memory_write_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
-- **Byte-tail termination in write kernel**: Fixed the `<32B` byte cleanup loop in `memory_write_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
-- **Unsigned loop/cleanup branching in read kernel**: Fixed `memory_read_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
-- **Byte-tail termination in read kernel**: Fixed the `<32B` byte cleanup loop in `memory_read_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
-- **Unsigned loop/cleanup branching in copy kernel**: Fixed `memory_copy_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
-- **Byte-tail termination in copy kernel**: Fixed the `<32B` byte cleanup loop in `memory_copy_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
+- **`size_t`-safe branch/cleanup fixes across ARM64 bandwidth kernels**: Unified loop/cleanup/byte-tail control flow in forward, reverse, strided, and random read/write/copy kernels to use unsigned or zero/non-zero termination semantics (`b.hs`/`b.lo`/`b.ls`, `cbz`, `b.ne`), and fixed reverse cleanup exit direction plus reverse copy byte-tail pointer initialization for correct full-range behavior.
 
 ## [0.52.7] - 2026-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
 - **Unsigned loop/cleanup branching in write kernel**: Fixed `memory_write_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
 - **Byte-tail termination in write kernel**: Fixed the `<32B` byte cleanup loop in `memory_write_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
+- **Unsigned loop/cleanup branching in read kernel**: Fixed `memory_read_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
+- **Byte-tail termination in read kernel**: Fixed the `<32B` byte cleanup loop in `memory_read_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
 
 ## [0.52.7] - 2026-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
 - **`size_t`-safe branch/cleanup fixes across ARM64 bandwidth kernels**: Unified loop/cleanup/byte-tail control flow in forward, reverse, strided, and random read/write/copy kernels to use unsigned or zero/non-zero termination semantics (`b.hs`/`b.lo`/`b.ls`, `cbz`, `b.ne`), and fixed reverse cleanup exit direction plus reverse copy byte-tail pointer initialization for correct full-range behavior.
 - **Mode-aware memory cap validation for `-only-bandwidth` / `-only-latency` / `-patterns`**: Updated `validate_config()` to compute per-buffer limits using the active main-buffer count (1/2/3) instead of always dividing by 3, preventing unnecessary buffer-size capping in reduced-buffer modes while keeping total-memory safeguards intact.
+- **Main-buffer total-memory overflow guard in allocator**: Added missing checked-add overflow validation when including the main latency buffer in `allocate_all_buffers()` total-memory accounting, and added a targeted unit test to lock in the overflow failure path.
 
 ## [0.52.7] - 2026-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Zero-access latency chase safety**: Fixed `memory_latency_chase_asm` to return immediately when `count == 0`, preventing an unnecessary dereference when no pointer-chasing accesses are requested.
 - **Unsigned loop termination in latency chase**: Fixed loop branch conditions in `memory_latency_chase_asm` to use counter-based `b.ne` termination, ensuring correct behavior for full `size_t` ranges.
 - **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
+- **Unsigned loop/cleanup branching in write kernel**: Fixed `memory_write_loop_asm` to use unsigned branch conditions (`b.lo`/`b.hs`) for block and cleanup thresholds, ensuring correct behavior across the full `size_t` range.
+- **Byte-tail termination in write kernel**: Fixed the `<32B` byte cleanup loop in `memory_write_loop_asm` to use zero/non-zero termination (`cbz`/`b.ne`) instead of signed conditions, preventing edge-case misbehavior with large unsigned counters.
 
 ## [0.52.7] - 2026-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.8] - 2026-03-07
+
+### Fixed
+- **Zero-access latency chase safety**: Fixed `memory_latency_chase_asm` to return immediately when `count == 0`, preventing an unnecessary dereference when no pointer-chasing accesses are requested.
+- **Unsigned loop termination in latency chase**: Fixed loop branch conditions in `memory_latency_chase_asm` to use counter-based `b.ne` termination, ensuring correct behavior for full `size_t` ranges.
+- **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
+
 ## [0.52.7] - 2026-01-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In the Terminal, go to the directory with `memory_benchmark` and use these comma
     Example output:
     ```text
     Copyright 2025-2026 Timo Heimonen <timo.heimonen@proton.me>
-    Version: 0.52.7 by Timo Heimonen <timo.heimonen@proton.me>
+    Version: 0.52.8 by Timo Heimonen <timo.heimonen@proton.me>
     License: GNU GPL v3. See <https://www.gnu.org/licenses/>
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -228,7 +228,7 @@ For usage documentation, command-line options reference, best practices, and det
 
 ## Example output (Mac Mini M4 24GB)
 ```text
------ macOS-memory-benchmark v0.52.7 -----
+----- macOS-memory-benchmark v0.52.8 -----
 Copyright 2025-2026 Timo Heimonen <timo.heimonen@proton.me>
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -284,7 +284,7 @@ Cache Latency Tests (single-threaded, pointer chase):
 Done. Total execution time: 43.48166 s
 ```
 ```text
------ macOS-memory-benchmark v0.52.7 -----
+----- macOS-memory-benchmark v0.52.8 -----
 Copyright 2025-2026 Timo Heimonen <timo.heimonen@proton.me>
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -61,12 +61,14 @@ The core of the performance measurement resides in the [`src/asm/`](src/asm/) di
 - **Read**: 512-byte block reads with XOR checksums to prevent dead code elimination by the compiler. See [`memory_read.s`](src/asm/memory_read.s).
 - **Write**: Utilizes non-temporal stores (`stnp`) to minimize cache pollution. See [`memory_write.s`](src/asm/memory_write.s).
 - **Copy**: Optimized using pair loads and stores to achieve maximum throughput. See [`memory_copy.s`](src/asm/memory_copy.s).
+- **`size_t`-safe control flow**: Sequential kernels use unsigned and zero/non-zero loop termination semantics for full-range correctness (`b.hs`/`b.lo`/`b.ls`, `cbz`, `b.ne`) instead of signed comparisons.
 
 ### 3.2 Latency Measurements
 
 - **Pointer-chasing**: Implemented with 8-way loop unrolling. See [`memory_latency.s`](src/asm/memory_latency.s).
-- **Memory Barriers**: `dsb`, `isb`, and `dmb` instructions are used to strictly isolate measurement windows.
-- **TLB Pre-touch**: The Translation Lookaside Buffer (TLB) is pre-loaded to ensure address translation does not contaminate latency measurements.
+- **Zero-access safety**: `memory_latency_chase_asm` returns immediately when `count == 0`, avoiding unnecessary dereference in no-access runs.
+- **Full-range loop correctness**: Loop termination uses counter-based zero/non-zero control (`subs` + `b.ne`) to remain correct for full `size_t` ranges.
+- **Measurement-window purity**: Pre-touch and barrier overhead (`ldr` preload, `dsb/isb`, `dmb`) was removed from the chase kernel so timed latency reflects dependent pointer loads only.
 - **Dependencies**: Built with true data dependencies, ensuring the measurement reflects actual latency rather than throughput.
 
 ### 3.3 Register Usage and SIMD
@@ -220,6 +222,7 @@ Dedicated ARM64 assembly functions for each pattern:
 - Random: [`memory_read_random.s`](src/asm/memory_read_random.s), [`memory_write_random.s`](src/asm/memory_write_random.s), [`memory_copy_random.s`](src/asm/memory_copy_random.s)
 
 All assembly functions use NEON SIMD (32-byte loads/stores), modulo arithmetic for bounds safety, and XOR checksum accumulation.
+Loop and cleanup control flow is standardized on unsigned or zero/non-zero termination semantics for `size_t` counters. Reverse kernels also include corrected cleanup exit direction and reverse copy byte-tail pointer initialization to ensure full-range correctness.
 
 **Integration:**
 
@@ -239,7 +242,7 @@ The software implements a sophisticated dual-output system designed for both hum
 
 **Message Architecture:**
 
-The console output uses a modular message system ([`src/output/console/messages/`](src/output/console/messages/)) with 10 specialized message modules:
+The console output uses a modular message system ([`src/output/console/messages/`](src/output/console/messages/)) with 9 specialized message modules:
 - [`cache_messages.cpp`](src/output/console/messages/cache_messages.cpp): Cache test result formatting
 - [`config_messages.cpp`](src/output/console/messages/config_messages.cpp): Configuration display
 - [`error_messages.cpp`](src/output/console/messages/error_messages.cpp): Error reporting with centralized prefixes
@@ -267,7 +270,7 @@ All numeric output uses precision constants from [`constants.h`](src/core/config
 
 **JSON Architecture:**
 
-The JSON export subsystem ([`src/output/json/json_output/`](src/output/json/json_output/)) consists of 7 specialized modules:
+The JSON export subsystem ([`src/output/json/json_output/`](src/output/json/json_output/)) consists of 6 specialized implementation modules:
 
 - **JSON Builder** ([`builder.cpp`](src/output/json/json_output/builder.cpp)): Constructs the root JSON structure with standardized field ordering (v0.52.4)
 - **File Writer** ([`file_writer.cpp`](src/output/json/json_output/file_writer.cpp)): Handles file I/O with error handling
@@ -305,7 +308,7 @@ JSON parsing and generation uses the nlohmann/json library ([`src/third_party/nl
 
 The software includes a comprehensive testing suite:
 
-- **Testing Framework**: 183 tests across 8 test files (3,200 lines) using the GoogleTest framework. See [`tests/`](tests/) directory.
+- **Testing Framework**: 199 tests across 8 test files using the GoogleTest framework. See [`tests/`](tests/) directory.
 - **Test Organization**: Tests are separated into unit tests and integration tests (v0.52.1). Three test targets available: `make test` (unit tests only, faster development cycle), `make test-integration` (integration tests only), and `make test-all` (complete test suite).
 - **Coverage Areas**: Memory allocation and initialization, buffer management, configuration validation and parsing, benchmark execution, pattern validation, message formatting, memory utilities.
 - **Doxygen-compliant documentation** at the source code level.

--- a/src/asm/asm_functions.h
+++ b/src/asm/asm_functions.h
@@ -63,8 +63,9 @@ extern "C" {
      * @brief Pointer chasing loop for latency measurement (assembly)
      * @param start_pointer Starting pointer for pointer-chasing chain
      * @param count Number of pointer-chasing accesses to perform
+     * @return Final pointer after chasing count links
      */
-    void memory_latency_chase_asm(uintptr_t* start_pointer, size_t count);
+    uintptr_t* memory_latency_chase_asm(uintptr_t* start_pointer, size_t count);
     
     // Pattern-specific assembly functions
     // Reverse sequential
@@ -151,4 +152,3 @@ extern "C" {
 /** @} */
 
 #endif // ASM_FUNCTIONS_H
-

--- a/src/asm/memory_copy.s
+++ b/src/asm/memory_copy.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/asm/memory_copy.s
+++ b/src/asm/memory_copy.s
@@ -45,7 +45,7 @@ copy_loop_start_nt512:      // Main 512B block loop
     // Only x3 (offset) and x5 (remaining) change per iteration.
     subs x5, x2, x3         // remaining = count - offset
     cmp x5, x4              // remaining < step?
-    b.lt copy_loop_cleanup  // If less, handle remaining bytes
+    b.lo copy_loop_cleanup  // If less (unsigned), handle remaining bytes
 
     // Calculate current addresses
     add x6, x1, x3          // src_addr = base + offset
@@ -104,7 +104,7 @@ copy_loop_cleanup:          // Tail handling when <512B remain
     // This minimizes branches while ensuring exact byte count handling.
     // Larger chunks first for better performance on unaligned remainders.
     cmp x3, x2              // offset == count?
-    b.ge copy_loop_end      // If done, exit
+    b.hs copy_loop_end      // If done (unsigned >=), exit
 
     subs x5, x2, x3         // Recalc remaining (x5)
     add x6, x1, x3          // src_addr = src + offset
@@ -112,7 +112,7 @@ copy_loop_cleanup:          // Tail handling when <512B remain
 
     // Handle 256B chunks (8 ldp/stnp pairs)
     cmp x5, #256              // Check if >= 256 bytes remain
-    b.lt cleanup_128          // If less, handle smaller chunks
+    b.lo cleanup_128          // If less (unsigned), handle smaller chunks
     ldp q0, q1, [x6, #0]      // Load first pair (32B)
     ldp q2, q3, [x6, #32]     // Load second pair (32B)
     ldp q4, q5, [x6, #64]     // Load third pair (32B)
@@ -135,7 +135,7 @@ copy_loop_cleanup:          // Tail handling when <512B remain
 
 cleanup_128:                  // Handle 128B chunks (4 ldp + 4 stnp)
     cmp x5, #128              // Check if >= 128 bytes remain
-    b.lt cleanup_64           // If less, handle smaller chunks
+    b.lo cleanup_64           // If less (unsigned), handle smaller chunks
     ldp q0, q1, [x6, #0]      // Load first pair (32B)
     ldp q2, q3, [x6, #32]     // Load second pair (32B)
     ldp q4, q5, [x6, #64]     // Load third pair (32B)
@@ -150,7 +150,7 @@ cleanup_128:                  // Handle 128B chunks (4 ldp + 4 stnp)
 
 cleanup_64:                   // Handle 64B chunks (2 ldp + 2 stnp)
     cmp x5, #64               // Check if >= 64 bytes remain
-    b.lt cleanup_32           // If less, handle smaller chunks
+    b.lo cleanup_32           // If less (unsigned), handle smaller chunks
     ldp q0, q1, [x6, #0]      // Load first pair (32B)
     ldp q2, q3, [x6, #32]     // Load second pair (32B)
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal)
@@ -161,7 +161,7 @@ cleanup_64:                   // Handle 64B chunks (2 ldp + 2 stnp)
 
 cleanup_32:                   // Handle 32B chunk (1 ldp + 1 stnp)
     cmp x5, #32               // Check if >= 32 bytes remain
-    b.lt copy_cleanup_byte    // If less, handle byte tail
+    b.lo copy_cleanup_byte    // If less (unsigned), handle byte tail
     ldp q0, q1, [x6, #0]      // Load pair (32B)
     stnp q0, q1, [x7, #0]     // Store pair (non-temporal)
     add x6, x6, #32           // Advance source pointer by 32B
@@ -171,12 +171,11 @@ cleanup_32:                   // Handle 32B chunk (1 ldp + 1 stnp)
 copy_cleanup_byte:           // Byte tail for final <32B
     // Final byte-by-byte copy for <32B remainder. Expected to be rare in
     // bandwidth benchmarks but ensures correctness for any input size.
-    cmp x5, #0               // Check if any bytes remain
-    b.le copy_loop_end        // If none, exit
+    cbz x5, copy_loop_end     // If none remain, exit
     ldrb w8, [x6], #1        // Load byte, post-increment source
     strb w8, [x7], #1        // Store byte, post-increment destination
     subs x5, x5, #1          // Decrement remaining count
-    b.gt copy_cleanup_byte    // Loop if more bytes remain
+    b.ne copy_cleanup_byte    // Loop while bytes remain
 
 copy_loop_end:              // Return to caller
     ret                     // Return

--- a/src/asm/memory_copy_random.s
+++ b/src/asm/memory_copy_random.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -49,7 +49,7 @@ copy_random_loop:              // Main random access loop
     
     // Check if done
     cmp x4, x3              // i >= num_accesses?
-    b.ge copy_random_end    // If done, exit
+    b.hs copy_random_end    // If done (unsigned >=), exit
     
     // Load index: indices[i]
     // Array indexing: indices[i] = *(indices + i * sizeof(size_t))
@@ -76,4 +76,3 @@ copy_random_loop:              // Main random access loop
 
 copy_random_end:              // Return to caller
     ret                     // Return
-

--- a/src/asm/memory_copy_reverse.s
+++ b/src/asm/memory_copy_reverse.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -47,11 +47,11 @@ copy_reverse_loop_start_nt512:      // Main 512B block loop (reverse direction)
     // Loop invariants: x5=512B block size, x0/x1 are base pointers.
     // Only x3 (dst_end), x4 (src_end) and x6 (remaining) change per iteration.
     cmp x3, x0              // dst_end <= dst?
-    b.le copy_reverse_loop_end      // If done, exit
+    b.ls copy_reverse_loop_end      // If done (unsigned <=), exit
     
     sub x6, x3, x0          // remaining = dst_end - dst
     cmp x6, x5              // remaining < step?
-    b.lt copy_reverse_cleanup  // If less, handle remaining bytes
+    b.lo copy_reverse_cleanup  // If less (unsigned), handle remaining bytes
     
     // Calculate current addresses (working backwards from end)
     sub x7, x3, #512        // dst_block_start = dst_end - 512
@@ -111,7 +111,7 @@ copy_reverse_cleanup:          // Tail handling when <512B remain
     // This minimizes branches while ensuring exact byte count handling.
     // Larger chunks first for better performance on unaligned remainders.
     cmp x3, x0              // dst_end <= dst?
-    b.ge copy_reverse_loop_end      // If done, exit
+    b.ls copy_reverse_loop_end      // If done (unsigned <=), exit
 
     subs x6, x3, x0         // Recalc remaining (x6)
     sub x7, x3, x6           // dst_block_start = dst_end - remaining
@@ -119,7 +119,7 @@ copy_reverse_cleanup:          // Tail handling when <512B remain
 
     // Handle 256B chunks (8 ldp/stnp pairs)
     cmp x6, #256              // Check if >= 256 bytes remain
-    b.lt copy_reverse_cleanup_128          // If less, handle smaller chunks
+    b.lo copy_reverse_cleanup_128          // If less (unsigned), handle smaller chunks
     sub x7, x3, #256          // dst_block_start = dst_end - 256
     sub x8, x4, #256          // src_block_start = src_end - 256
     ldp q0, q1, [x8, #0]      // Load first pair (32B)
@@ -144,7 +144,7 @@ copy_reverse_cleanup:          // Tail handling when <512B remain
 
 copy_reverse_cleanup_128:                  // Handle 128B chunks (4 ldp + 4 stnp)
     cmp x6, #128              // Check if >= 128 bytes remain
-    b.lt copy_reverse_cleanup_64           // If less, handle smaller chunks
+    b.lo copy_reverse_cleanup_64           // If less (unsigned), handle smaller chunks
     sub x7, x3, #128          // dst_block_start = dst_end - 128
     sub x8, x4, #128          // src_block_start = src_end - 128
     ldp q0, q1, [x8, #0]      // Load first pair (32B)
@@ -161,7 +161,7 @@ copy_reverse_cleanup_128:                  // Handle 128B chunks (4 ldp + 4 stnp
 
 copy_reverse_cleanup_64:                   // Handle 64B chunks (2 ldp + 2 stnp)
     cmp x6, #64               // Check if >= 64 bytes remain
-    b.lt copy_reverse_cleanup_32           // If less, handle smaller chunks
+    b.lo copy_reverse_cleanup_32           // If less (unsigned), handle smaller chunks
     sub x7, x3, #64           // dst_block_start = dst_end - 64
     sub x8, x4, #64           // src_block_start = src_end - 64
     ldp q0, q1, [x8, #0]      // Load first pair (32B)
@@ -174,7 +174,7 @@ copy_reverse_cleanup_64:                   // Handle 64B chunks (2 ldp + 2 stnp)
 
 copy_reverse_cleanup_32:                   // Handle 32B chunk (1 ldp + 1 stnp)
     cmp x6, #32               // Check if >= 32 bytes remain
-    b.lt copy_reverse_cleanup_byte    // If less, handle byte tail
+    b.lo copy_reverse_cleanup_byte    // If less (unsigned), handle byte tail
     sub x7, x3, #32           // dst_block_start = dst_end - 32
     sub x8, x4, #32           // src_block_start = src_end - 32
     ldp q0, q1, [x8, #0]      // Load pair (32B)
@@ -186,11 +186,10 @@ copy_reverse_cleanup_32:                   // Handle 32B chunk (1 ldp + 1 stnp)
 copy_reverse_cleanup_byte:           // Byte tail for final <32B
     // Final byte-by-byte copy for <32B remainder. Expected to be rare in
     // bandwidth benchmarks but ensures correctness for any input size.
-    cmp x6, #0               // Check if any bytes remain
-    b.le copy_reverse_loop_end        // If none, exit
-    // Initialize pointers to last byte (one before end)
-    sub x7, x3, #1           // dst_addr = dst_end - 1
-    sub x8, x4, #1           // src_addr = src_end - 1
+    cbz x6, copy_reverse_loop_end     // If none remain, exit
+    // Initialize pointers to end; pre-indexed loads/stores decrement first.
+    mov x7, x3               // dst_addr = dst_end
+    mov x8, x4               // src_addr = src_end
     // Use pre-indexed addressing to auto-decrement pointers, eliminating
     // redundant address calculations. This reduces loop overhead from 5
     // instructions (sub x7, sub x8, ldrb, strb, sub x3/x4) to 3 instructions.
@@ -198,8 +197,7 @@ copy_reverse_cleanup_byte_loop:
     ldrb w9, [x8, #-1]!      // Pre-decrement src_addr, then load byte
     strb w9, [x7, #-1]!      // Pre-decrement dst_addr, then store byte
     subs x6, x6, #1          // Decrement remaining count, set flags
-    b.gt copy_reverse_cleanup_byte_loop // Loop if more bytes remain
+    b.ne copy_reverse_cleanup_byte_loop // Loop while bytes remain
 
 copy_reverse_loop_end:              // Return to caller
     ret                     // Return
-

--- a/src/asm/memory_copy_strided.s
+++ b/src/asm/memory_copy_strided.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -51,7 +51,7 @@ copy_strided_loop:              // Main strided access loop
 
     // Check termination: iteration_count >= num_iterations?
     cmp x5, x4              // iteration_count >= num_iterations?
-    b.ge copy_strided_done  // If done, exit
+    b.hs copy_strided_done  // If done (unsigned >=), exit
 
     // Calculate current addresses: src + (offset % byteCount), dst + (offset % byteCount)
     // Use modulo operation: offset % byteCount = offset - (offset / byteCount) * byteCount
@@ -78,4 +78,3 @@ copy_strided_loop:              // Main strided access loop
 
 copy_strided_done:          // Return to caller
     ret                     // Return
-

--- a/src/asm/memory_latency.s
+++ b/src/asm/memory_latency.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/asm/memory_latency.s
+++ b/src/asm/memory_latency.s
@@ -16,7 +16,7 @@
 // memory_latency_chase_asm
 // -----------------------------------------------------------------------------
 // C++ Prototype:
-//   extern "C" uint64_t memory_latency_chase_asm(uintptr_t* start_pointer, size_t count);
+//   extern "C" uintptr_t* memory_latency_chase_asm(uintptr_t* start_pointer, size_t count);
 // Purpose:
 //   Measure load‑to‑use latency via dependent pointer chasing. Each load feeds
 //   the address of the next, forming a serialized chain. Loop is unrolled by 8

--- a/src/asm/memory_latency.s
+++ b/src/asm/memory_latency.s
@@ -29,32 +29,19 @@
 // Clobbers:
 //   x4‑x5 (temporaries for iteration counts)
 // Implementation Notes:
-//   * Uses barriers (dsb/isb/dmb) to isolate measurement window and reduce
-//     speculative side effects across the unrolled section.
 //   * No prefetching: intentional to keep strictly serialized accesses.
 // -----------------------------------------------------------------------------
 
 .global _memory_latency_chase_asm
 .align 4
 _memory_latency_chase_asm:
-    // Pre-touch to ensure TLB entries are loaded before timing measurement.
-    // This prevents TLB miss overhead from contaminating latency results.
-    ldr x4, [x0]                // Prime the first access but don't use result yet
-    // DSB ISH: Ensure TLB preload completes before timing measurement.
-    // Prevents speculative execution from contaminating latency results.
-    dsb ish                     // Data synchronization barrier (inner shareable)
-    isb                         // Instruction synchronization barrier
+    cbz x1, latency_end         // No dereferences requested
 
     // Compute unrolled iterations and remainder for exact count handling
     lsr x4, x1, #3              // x4 = count / 8 (unrolled iterations)
     and x5, x1, #7              // x5 = count % 8 (remainder)
 
     cbz x4, latency_remainder   // Skip unrolled loop if no full groups
-
-    // DMB SY: Full system memory barrier to prevent reordering before measurement.
-    // Ensures all prior memory operations complete and prevents speculative loads
-    // from affecting the timing window.
-    dmb sy                      // Memory barrier to prevent reordering before measurement
 
 latency_loop_unrolled:          // 8 dependent loads per iteration
     // Use pointer chasing with 8x unrolling to minimize branch overhead while
@@ -72,12 +59,7 @@ latency_loop_unrolled:          // 8 dependent loads per iteration
     ldr x0, [x0]                // Load 8: x0 = *x0 (dependent on load 7)
     
     subs x4, x4, #1             // Decrement unrolled iteration count
-    b.gt latency_loop_unrolled  // Loop if more groups remain
-
-    // DMB SY: Full system memory barrier after unrolled section to ensure completion.
-    // Guarantees all loads in the measurement window have completed before
-    // proceeding to remainder handling or return.
-    dmb sy                      // Memory barrier after unrolled section to ensure completion
+    b.ne latency_loop_unrolled  // Loop if more groups remain
 
 latency_remainder:              // Handle remaining (0-7) dereferences
     // Process remainder with single dependent loads. Maintains same dependency
@@ -86,7 +68,7 @@ latency_remainder:              // Handle remaining (0-7) dereferences
 latency_single:                 // Single dependent dereference loop
     ldr x0, [x0]                // Load: x0 = *x0 (dependent chain)
     subs x5, x5, #1             // Decrement remainder count
-    b.gt latency_single         // Loop if more dereferences remain
+    b.ne latency_single         // Loop if more dereferences remain
 
 latency_end:                    // Return final pointer value
     ret                         // Return final pointer to prevent optimizations

--- a/src/asm/memory_read.s
+++ b/src/asm/memory_read.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/asm/memory_read.s
+++ b/src/asm/memory_read.s
@@ -56,7 +56,7 @@ read_loop_start_512:        // Main 512B block loop
     // x12 holds byte checksum. Only x3 (offset) and loop counters change.
     subs x5, x1, x3         // remaining = count - offset
     cmp x5, x4              // remaining < step?
-    b.lt read_loop_cleanup  // If less, handle remaining bytes
+    b.lo read_loop_cleanup  // If less (unsigned), handle remaining bytes
 
     add x6, x0, x3          // src_addr = base + offset
 
@@ -131,14 +131,14 @@ read_loop_cleanup:          // Tail handling when <512B remain
     // This minimizes branches while ensuring exact byte count handling.
     // Larger chunks first for better performance on unaligned remainders.
     cmp x3, x1              // offset == count?
-    b.ge read_loop_combine_sum // If done, combine sums
+    b.hs read_loop_combine_sum // If done (unsigned >=), combine sums
 
     subs x5, x1, x3         // Recalc remaining (x5)
     add x6, x0, x3          // src_addr = src + offset
 
     // 256B chunk (8 pair loads + XOR fold)
     cmp x5, #256              // Check if >= 256 bytes remain
-    b.lt read_cleanup_128     // If less, handle smaller chunks
+    b.lo read_cleanup_128     // If less (unsigned), handle smaller chunks
     ldp q4, q5, [x6, #0]      // Load first pair (32B)
     ldp q6, q7, [x6, #32]     // Load second pair (32B)
     ldp q16, q17, [x6, #64]   // Load third pair (32B)
@@ -169,7 +169,7 @@ read_loop_cleanup:          // Tail handling when <512B remain
 
 read_cleanup_128:              // 128B chunk
     cmp x5, #128               // Check if >= 128 bytes remain
-    b.lt read_cleanup_64        // If less, handle smaller chunks
+    b.lo read_cleanup_64        // If less (unsigned), handle smaller chunks
     ldp q4, q5, [x6, #0]        // Load first pair (32B)
     ldp q6, q7, [x6, #32]       // Load second pair (32B)
     ldp q16, q17, [x6, #64]     // Load third pair (32B)
@@ -187,7 +187,7 @@ read_cleanup_128:              // 128B chunk
 
 read_cleanup_64:               // 64B chunk
     cmp x5, #64                // Check if >= 64 bytes remain
-    b.lt read_cleanup_32        // If less, handle smaller chunks
+    b.lo read_cleanup_32        // If less (unsigned), handle smaller chunks
     ldp q4, q5, [x6, #0]       // Load first pair (32B)
     ldp q6, q7, [x6, #32]      // Load second pair (32B)
     eor v0.16b, v0.16b, v4.16b // Accumulate q4 into v0
@@ -199,7 +199,7 @@ read_cleanup_64:               // 64B chunk
 
 read_cleanup_32:               // 32B chunk
     cmp x5, #32                // Check if >= 32 bytes remain
-    b.lt read_cleanup_byte      // If less, handle byte tail
+    b.lo read_cleanup_byte      // If less (unsigned), handle byte tail
     ldp q4, q5, [x6, #0]       // Load pair (32B)
     eor v0.16b, v0.16b, v4.16b  // Accumulate q4 into v0
     eor v1.16b, v1.16b, v5.16b  // Accumulate q5 into v1
@@ -207,12 +207,11 @@ read_cleanup_32:               // 32B chunk
     sub x5, x5, #32            // Decrement remaining count by 32B
 
 read_cleanup_byte:             // Byte tail (<32B)
-    cmp x5, #0                 // Check if any bytes remain
-    b.le read_loop_combine_sum // If none, combine checksums
+    cbz x5, read_loop_combine_sum // If none remain, combine checksums
     ldrb w13, [x6], #1         // Load byte, post-increment source
     eor x12, x12, x13          // XOR byte into accumulator
     subs x5, x5, #1            // Decrement remaining count
-    b.gt read_cleanup_byte     // Loop if more bytes remain
+    b.ne read_cleanup_byte     // Loop while bytes remain
 
 read_loop_combine_sum:         // Final reduction + result write-back
     // Combine accumulators v0-v3 -> v0.

--- a/src/asm/memory_read_random.s
+++ b/src/asm/memory_read_random.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -55,7 +55,7 @@ read_random_loop:              // Main random access loop
     
     // Check if done
     cmp x3, x2              // i >= num_accesses?
-    b.ge read_random_combine_sum // If done, combine checksums
+    b.hs read_random_combine_sum // If done (unsigned >=), combine checksums
     
     // Load index: indices[i]
     // Array indexing: indices[i] = *(indices + i * sizeof(size_t))
@@ -87,4 +87,3 @@ read_random_combine_sum:         // Final reduction + result write-back
     eor x0, x12, x13             // Combine both halves into final checksum
     
     ret                         // Return checksum in x0
-

--- a/src/asm/memory_read_reverse.s
+++ b/src/asm/memory_read_reverse.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -58,12 +58,12 @@ read_reverse_loop_start_512:        // Main 512B block loop (reverse direction)
     // Loop invariants: x4=512B block size, accumulators v0-v3 accumulate XOR,
     // x12 holds byte checksum. Only x3 (end_ptr) and loop counters change.
     cmp x3, x0              // end_ptr <= src?
-    b.le read_reverse_loop_combine_sum // If done, combine sums
+    b.ls read_reverse_loop_combine_sum // If done (unsigned <=), combine sums
     
     // Calculate remaining bytes
     sub x5, x3, x0          // remaining = end_ptr - src
     cmp x5, x4              // remaining < step?
-    b.lt read_reverse_cleanup  // If less, handle remaining bytes
+    b.lo read_reverse_cleanup  // If less (unsigned), handle remaining bytes
 
     // Calculate start address for this block (subtract block size from end)
     sub x7, x3, #512        // block_start = end_ptr - 512
@@ -139,14 +139,14 @@ read_reverse_cleanup:          // Tail handling when <512B remain
     // This minimizes branches while ensuring exact byte count handling.
     // Larger chunks first for better performance on unaligned remainders.
     cmp x3, x0              // end_ptr <= src?
-    b.le read_reverse_loop_combine_sum // If done, combine sums
+    b.ls read_reverse_loop_combine_sum // If done (unsigned <=), combine sums
 
     subs x5, x3, x0         // Recalc remaining (x5)
     sub x7, x3, x5          // block_start = end_ptr - remaining
 
     // 256B chunk (8 pair loads + XOR fold)
     cmp x5, #256              // Check if >= 256 bytes remain
-    b.lt read_reverse_cleanup_128     // If less, handle smaller chunks
+    b.lo read_reverse_cleanup_128     // If less (unsigned), handle smaller chunks
     sub x7, x3, #256          // block_start = end_ptr - 256
     ldp q4, q5, [x7, #0]      // Load first pair (32B)
     ldp q6, q7, [x7, #32]     // Load second pair (32B)
@@ -178,7 +178,7 @@ read_reverse_cleanup:          // Tail handling when <512B remain
 
 read_reverse_cleanup_128:              // 128B chunk
     cmp x5, #128               // Check if >= 128 bytes remain
-    b.lt read_reverse_cleanup_64        // If less, handle smaller chunks
+    b.lo read_reverse_cleanup_64        // If less (unsigned), handle smaller chunks
     sub x7, x3, #128            // block_start = end_ptr - 128
     ldp q4, q5, [x7, #0]        // Load first pair (32B)
     ldp q6, q7, [x7, #32]       // Load second pair (32B)
@@ -197,7 +197,7 @@ read_reverse_cleanup_128:              // 128B chunk
 
 read_reverse_cleanup_64:               // 64B chunk
     cmp x5, #64                // Check if >= 64 bytes remain
-    b.lt read_reverse_cleanup_32        // If less, handle smaller chunks
+    b.lo read_reverse_cleanup_32        // If less (unsigned), handle smaller chunks
     sub x7, x3, #64             // block_start = end_ptr - 64
     ldp q4, q5, [x7, #0]       // Load first pair (32B)
     ldp q6, q7, [x7, #32]      // Load second pair (32B)
@@ -210,7 +210,7 @@ read_reverse_cleanup_64:               // 64B chunk
 
 read_reverse_cleanup_32:               // 32B chunk
     cmp x5, #32                // Check if >= 32 bytes remain
-    b.lt read_reverse_cleanup_byte      // If less, handle byte tail
+    b.lo read_reverse_cleanup_byte      // If less (unsigned), handle byte tail
     sub x7, x3, #32             // block_start = end_ptr - 32
     ldp q4, q5, [x7, #0]       // Load pair (32B)
     eor v0.16b, v0.16b, v4.16b  // Accumulate q4 into v0
@@ -219,13 +219,13 @@ read_reverse_cleanup_32:               // 32B chunk
     sub x5, x5, #32            // Decrement remaining count by 32B
 
 read_reverse_cleanup_byte:             // Byte tail (<32B)
-    subs x5, x5, #1            // Decrement and set condition flags
-    b.lt read_reverse_loop_combine_sum // If < 0, no bytes remain
+    cbz x5, read_reverse_loop_combine_sum // If no bytes remain, combine sums
     sub x7, x3, #1              // addr = end_ptr - 1
     ldrb w13, [x7]             // Load byte from address
     eor x12, x12, x13          // XOR byte into accumulator
     sub x3, x3, #1             // Decrement end_ptr
-    b read_reverse_cleanup_byte // Loop again
+    subs x5, x5, #1            // Decrement remaining count
+    b.ne read_reverse_cleanup_byte // Loop while bytes remain
 
 read_reverse_loop_combine_sum:         // Final reduction + result write-back
     // Combine accumulators v0-v3 -> v0.

--- a/src/asm/memory_read_strided.s
+++ b/src/asm/memory_read_strided.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -57,7 +57,7 @@ read_strided_loop:              // Main strided access loop
 
     // Check termination: iteration_count >= num_iterations?
     cmp x4, x3              // iteration_count >= num_iterations?
-    b.ge read_strided_combine_sum  // If done, combine checksums
+    b.hs read_strided_combine_sum  // If done (unsigned >=), combine checksums
 
     // Calculate current address: src + (offset % byteCount)
     // Use modulo operation: offset % byteCount = offset - (offset / byteCount) * byteCount
@@ -90,4 +90,3 @@ read_strided_combine_sum:       // Combine checksums and return
     eor x0, x12, x13             // Combine both halves into final checksum
     
     ret                         // Return checksum in x0
-

--- a/src/asm/memory_write.s
+++ b/src/asm/memory_write.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/asm/memory_write.s
+++ b/src/asm/memory_write.s
@@ -75,7 +75,7 @@ write_loop_start_nt512:     // Main 512B block loop
     // Only x3 (offset) and x5 (remaining) change per iteration.
     subs x5, x1, x3         // remaining = count - offset
     cmp x5, x4              // remaining < step?
-    b.lt write_loop_cleanup // If less, handle remaining bytes
+    b.lo write_loop_cleanup // If less (unsigned), handle remaining bytes
 
     add x7, x0, x3          // dst_addr = base + offset
 
@@ -109,14 +109,14 @@ write_loop_cleanup:         // Tail handling when <512B remain
     // This minimizes branches while ensuring exact byte count handling.
     // Larger chunks first for better performance on unaligned remainders.
     cmp x3, x1              // offset == count?
-    b.ge write_loop_end     // If done, exit
+    b.hs write_loop_end     // If done (unsigned >=), exit
 
     subs x5, x1, x3         // Recalc remaining (x5)
     add x7, x0, x3          // dst_addr = dst + offset
 
     // Handle 256B chunks (8 stnp pairs)
     cmp x5, #256              // Check if >= 256 bytes remain
-    b.lt write_cleanup_128    // If less, handle smaller chunks
+    b.lo write_cleanup_128    // If less (unsigned), handle smaller chunks
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal, 32B)
     stnp q2, q3, [x7, #32]    // Store second pair (non-temporal, 32B)
     stnp q4, q5, [x7, #64]    // Store third pair (non-temporal, 32B)
@@ -130,7 +130,7 @@ write_loop_cleanup:         // Tail handling when <512B remain
 
 write_cleanup_128:            // 128B chunk
     cmp x5, #128              // Check if >= 128 bytes remain
-    b.lt write_cleanup_64      // If less, handle smaller chunks
+    b.lo write_cleanup_64      // If less (unsigned), handle smaller chunks
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal, 32B)
     stnp q2, q3, [x7, #32]    // Store second pair (non-temporal, 32B)
     stnp q4, q5, [x7, #64]    // Store third pair (non-temporal, 32B)
@@ -140,7 +140,7 @@ write_cleanup_128:            // 128B chunk
 
 write_cleanup_64:             // 64B chunk
     cmp x5, #64               // Check if >= 64 bytes remain
-    b.lt write_cleanup_32      // If less, handle smaller chunks
+    b.lo write_cleanup_32      // If less (unsigned), handle smaller chunks
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal, 32B)
     stnp q2, q3, [x7, #32]    // Store second pair (non-temporal, 32B)
     add x7, x7, #64           // Advance destination pointer by 64B
@@ -148,7 +148,7 @@ write_cleanup_64:             // 64B chunk
 
 write_cleanup_32:             // 32B chunk
     cmp x5, #32               // Check if >= 32 bytes remain
-    b.lt write_cleanup_byte    // If less, handle byte tail
+    b.lo write_cleanup_byte    // If less (unsigned), handle byte tail
     stnp q0, q1, [x7, #0]     // Store pair (non-temporal, 32B)
     add x7, x7, #32           // Advance destination pointer by 32B
     sub x5, x5, #32           // Decrement remaining count by 32B
@@ -157,11 +157,10 @@ write_cleanup_byte:            // Byte tail (<32B)
     // Final byte-by-byte write for <32B remainder. Expected to be rare in
     // bandwidth benchmarks but ensures correctness for any input size.
     // Using wzr (zero register) avoids needing to load/store a zero value.
-    cmp x5, #0                // Check if any bytes remain
-    b.le write_loop_end        // If none, exit
+    cbz x5, write_loop_end     // If none remain, exit
     strb wzr, [x7], #1         // Store zero byte, post-increment destination
     subs x5, x5, #1           // Decrement remaining count
-    b.gt write_cleanup_byte    // Loop if more bytes remain
+    b.ne write_cleanup_byte    // Loop while bytes remain
 
 write_loop_end:             // Return to caller
     ret                     // Return

--- a/src/asm/memory_write_random.s
+++ b/src/asm/memory_write_random.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -54,7 +54,7 @@ write_random_loop:              // Main random access loop
     
     // Check if done
     cmp x3, x2              // i >= num_accesses?
-    b.ge write_random_end   // If done, exit
+    b.hs write_random_end   // If done (unsigned >=), exit
     
     // Load index: indices[i]
     // Array indexing: indices[i] = *(indices + i * sizeof(size_t))
@@ -75,4 +75,3 @@ write_random_loop:              // Main random access loop
 
 write_random_end:             // Return to caller
     ret                     // Return
-

--- a/src/asm/memory_write_reverse.s
+++ b/src/asm/memory_write_reverse.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -77,11 +77,11 @@ write_reverse_loop_start_nt512:     // Main 512B block loop (reverse direction)
     // Loop invariants: x4=512B block size, all vectors (q0-q7, q16-q31) are zero.
     // Only x3 (end_ptr) and x5 (remaining) change per iteration.
     cmp x3, x0              // end_ptr <= dst?
-    b.le write_reverse_loop_end     // If done, exit
+    b.ls write_reverse_loop_end     // If done (unsigned <=), exit
     
     sub x5, x3, x0          // remaining = end_ptr - dst
     cmp x5, x4              // remaining < step?
-    b.lt write_reverse_cleanup // If less, handle remaining bytes
+    b.lo write_reverse_cleanup // If less (unsigned), handle remaining bytes
 
     sub x7, x3, #512        // block_start = end_ptr - 512
 
@@ -115,14 +115,14 @@ write_reverse_cleanup:         // Tail handling when <512B remain
     // This minimizes branches while ensuring exact byte count handling.
     // Larger chunks first for better performance on unaligned remainders.
     cmp x3, x0              // end_ptr <= dst?
-    b.ge write_reverse_loop_end     // If done, exit
+    b.ls write_reverse_loop_end     // If done (unsigned <=), exit
 
     subs x5, x3, x0         // Recalc remaining (x5)
     sub x7, x3, x5          // block_start = end_ptr - remaining
 
     // Handle 256B chunks (8 stnp pairs)
     cmp x5, #256              // Check if >= 256 bytes remain
-    b.lt write_reverse_cleanup_128    // If less, handle smaller chunks
+    b.lo write_reverse_cleanup_128    // If less (unsigned), handle smaller chunks
     sub x7, x3, #256          // block_start = end_ptr - 256
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal, 32B)
     stnp q2, q3, [x7, #32]    // Store second pair (non-temporal, 32B)
@@ -137,7 +137,7 @@ write_reverse_cleanup:         // Tail handling when <512B remain
 
 write_reverse_cleanup_128:            // 128B chunk
     cmp x5, #128              // Check if >= 128 bytes remain
-    b.lt write_reverse_cleanup_64      // If less, handle smaller chunks
+    b.lo write_reverse_cleanup_64      // If less (unsigned), handle smaller chunks
     sub x7, x3, #128          // block_start = end_ptr - 128
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal, 32B)
     stnp q2, q3, [x7, #32]    // Store second pair (non-temporal, 32B)
@@ -148,7 +148,7 @@ write_reverse_cleanup_128:            // 128B chunk
 
 write_reverse_cleanup_64:             // 64B chunk
     cmp x5, #64               // Check if >= 64 bytes remain
-    b.lt write_reverse_cleanup_32      // If less, handle smaller chunks
+    b.lo write_reverse_cleanup_32      // If less (unsigned), handle smaller chunks
     sub x7, x3, #64           // block_start = end_ptr - 64
     stnp q0, q1, [x7, #0]     // Store first pair (non-temporal, 32B)
     stnp q2, q3, [x7, #32]    // Store second pair (non-temporal, 32B)
@@ -157,7 +157,7 @@ write_reverse_cleanup_64:             // 64B chunk
 
 write_reverse_cleanup_32:             // 32B chunk
     cmp x5, #32               // Check if >= 32 bytes remain
-    b.lt write_reverse_cleanup_byte    // If less, handle byte tail
+    b.lo write_reverse_cleanup_byte    // If less (unsigned), handle byte tail
     sub x7, x3, #32           // block_start = end_ptr - 32
     stnp q0, q1, [x7, #0]     // Store pair (non-temporal, 32B)
     sub x3, x3, #32           // Advance end_ptr backwards by 32B
@@ -167,14 +167,12 @@ write_reverse_cleanup_byte:            // Byte tail (<32B)
     // Final byte-by-byte write for <32B remainder. Expected to be rare in
     // bandwidth benchmarks but ensures correctness for any input size.
     // Using wzr (zero register) avoids needing to load/store a zero value.
-    cmp x5, #0                // Check if any bytes remain
-    b.le write_reverse_loop_end        // If none, exit
+    cbz x5, write_reverse_loop_end     // If none remain, exit
     sub x7, x3, #1             // addr = end_ptr - 1
     strb wzr, [x7]            // Store zero byte
     sub x3, x3, #1           // Decrement end_ptr
     subs x5, x5, #1           // Decrement remaining count
-    b.gt write_reverse_cleanup_byte    // Loop if more bytes remain
+    b.ne write_reverse_cleanup_byte    // Loop while bytes remain
 
 write_reverse_loop_end:             // Return to caller
     ret                     // Return
-

--- a/src/asm/memory_write_strided.s
+++ b/src/asm/memory_write_strided.s
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ write_strided_loop:              // Main strided access loop
 
     // Check termination: iteration_count >= num_iterations?
     cmp x4, x3              // iteration_count >= num_iterations?
-    b.ge write_strided_done // If done, exit
+    b.hs write_strided_done // If done (unsigned >=), exit
 
     // Calculate current address: dst + (offset % byteCount)
     // Use modulo operation: offset % byteCount = offset - (offset / byteCount) * byteCount
@@ -77,4 +77,3 @@ write_strided_loop:              // Main strided access loop
 
 write_strided_done:         // Return to caller
     ret                     // Return
-

--- a/src/benchmark/benchmark_executor.cpp
+++ b/src/benchmark/benchmark_executor.cpp
@@ -51,7 +51,24 @@
 #include "core/config/constants.h"
 #include <atomic>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
+
+namespace {
+
+int calculate_cache_iterations_saturated(int iterations) {
+  if (iterations <= 0) {
+    return 0;
+  }
+
+  if (iterations > std::numeric_limits<int>::max() / Constants::CACHE_ITERATIONS_MULTIPLIER) {
+    return std::numeric_limits<int>::max();
+  }
+
+  return iterations * Constants::CACHE_ITERATIONS_MULTIPLIER;
+}
+
+}  // namespace
 
 /**
  * @brief Run main memory bandwidth tests (read, write, copy).
@@ -157,7 +174,7 @@ void run_single_cache_bandwidth_test(void* src_buffer, void* dst_buffer, size_t 
  */
 void run_cache_bandwidth_tests(const BenchmarkBuffers& buffers, const BenchmarkConfig& config,
                                TimingResults& timings, HighResTimer& test_timer) {
-  int cache_iterations = config.iterations * Constants::CACHE_ITERATIONS_MULTIPLIER;
+  int cache_iterations = calculate_cache_iterations_saturated(config.iterations);
   // Use user-specified threads if set, otherwise default to single-threaded for cache tests
   int cache_threads = config.user_specified_threads ? config.num_threads : Constants::SINGLE_THREAD;
   
@@ -260,18 +277,24 @@ void run_cache_latency_tests(const BenchmarkBuffers& buffers, const BenchmarkCon
  * @param[in]     buffers     Benchmark buffers (lat_buffer)
  * @param[in]     config      Configuration (lat_num_accesses)
  * @param[out]    timings     Timing results structure to populate
- * @param[out]    results     Results structure (not used for samples in main memory)
+ * @param[out]    results     Results structure for optional latency samples
  * @param[in,out] test_timer  High-resolution timer for measurements
  *
- * @note No sample collection for main memory latency (nullptr, 0 passed).
+ * @note Main memory average latency is always computed from a single continuous chase.
+ * @note When sample collection is enabled, samples are collected in a separate pass.
  * @note Progress indicator shown before test execution.
  */
 void run_main_memory_latency_test(const BenchmarkBuffers& buffers, const BenchmarkConfig& config,
-                                  TimingResults& timings, BenchmarkResults& results, HighResTimer& test_timer) {
+                                    TimingResults& timings, BenchmarkResults& results, HighResTimer& test_timer) {
   show_progress();
   warmup_latency(buffers.lat_buffer(), config.buffer_size);
   timings.total_lat_time_ns = run_latency_test(buffers.lat_buffer(), config.lat_num_accesses, test_timer,
                                                 nullptr, 0);
+
+  if (config.latency_sample_count > 0) {
+    (void)run_latency_test(buffers.lat_buffer(), config.lat_num_accesses, test_timer,
+                           &results.latency_samples, config.latency_sample_count);
+  }
 }
 
 /**

--- a/src/benchmark/benchmark_results.cpp
+++ b/src/benchmark/benchmark_results.cpp
@@ -42,6 +42,22 @@
 #include <limits>  // std::numeric_limits
 #include <cmath>   // std::isnan, std::isinf
 
+namespace {
+
+int calculate_cache_iterations_saturated(int iterations) {
+  if (iterations <= 0) {
+    return 0;
+  }
+
+  if (iterations > std::numeric_limits<int>::max() / Constants::CACHE_ITERATIONS_MULTIPLIER) {
+    return std::numeric_limits<int>::max();
+  }
+
+  return iterations * Constants::CACHE_ITERATIONS_MULTIPLIER;
+}
+
+}  // namespace
+
 /**
  * @brief Helper function to calculate bandwidth for a single memory level (main or cache).
  *
@@ -183,7 +199,7 @@ void calculate_bandwidth_results(const BenchmarkConfig& config, const TimingResu
                              results.read_bw_gb_s, results.write_bw_gb_s, results.copy_bw_gb_s);
   
   // Cache bandwidth calculations
-  int cache_iterations = config.iterations * Constants::CACHE_ITERATIONS_MULTIPLIER;
+  int cache_iterations = calculate_cache_iterations_saturated(config.iterations);
   
   if (config.use_custom_cache_size) {
     if (config.custom_buffer_size > 0) {

--- a/src/benchmark/latency_tests.cpp
+++ b/src/benchmark/latency_tests.cpp
@@ -36,10 +36,63 @@
 
 #include <vector>                // For std::vector
 #include <cstddef>               // For size_t
+#include <algorithm>             // For std::min
 
 #include "benchmark/benchmark_tests.h"  // Function declarations
 #include "core/timing/timer.h"  // HighResTimer
 #include "asm/asm_functions.h"  // Assembly function declarations
+
+/**
+ * @brief Run latency chase with optional per-sample collection.
+ *
+ * When sampling is enabled, this function guarantees that the total number of
+ * executed accesses equals num_accesses by distributing remainder accesses
+ * across early samples.
+ */
+static double run_latency_measurement(uintptr_t* lat_start_ptr,
+                                      size_t num_accesses,
+                                      HighResTimer& timer,
+                                      std::vector<double>* latency_samples,
+                                      int sample_count) {
+  if (num_accesses == 0) {
+    return 0.0;
+  }
+
+  if (latency_samples == nullptr || sample_count <= 0) {
+    timer.start();
+    (void)memory_latency_chase_asm(lat_start_ptr, num_accesses);
+    return timer.stop_ns();
+  }
+
+  latency_samples->clear();
+
+  size_t requested_samples = static_cast<size_t>(sample_count);
+  size_t effective_samples = std::min(requested_samples, num_accesses);
+  if (effective_samples == 0) {
+    return 0.0;
+  }
+
+  latency_samples->reserve(effective_samples);
+
+  size_t base_accesses = num_accesses / effective_samples;
+  size_t remainder_accesses = num_accesses % effective_samples;
+  uintptr_t* current_ptr = lat_start_ptr;
+
+  double total_duration_ns = 0.0;
+  for (size_t i = 0; i < effective_samples; ++i) {
+    size_t accesses_this_sample = base_accesses + (i < remainder_accesses ? 1 : 0);
+
+    timer.start();
+    current_ptr = memory_latency_chase_asm(current_ptr, accesses_this_sample);
+    double sample_duration_ns = timer.stop_ns();
+    double sample_latency_ns = sample_duration_ns / static_cast<double>(accesses_this_sample);
+
+    latency_samples->push_back(sample_latency_ns);
+    total_duration_ns += sample_duration_ns;
+  }
+
+  return total_duration_ns;
+}
 
 /**
  * @brief Executes the single-threaded memory latency benchmark.
@@ -77,7 +130,7 @@
  * @see setup_latency_chain() for buffer initialization
  */
 double run_latency_test(void *buffer, size_t num_accesses, HighResTimer &timer,
-                        std::vector<double> *latency_samples, int sample_count) {
+                         std::vector<double> *latency_samples, int sample_count) {
   // Early validation: return 0 if no accesses requested
   if (num_accesses == 0) {
     return 0.0;
@@ -85,38 +138,8 @@ double run_latency_test(void *buffer, size_t num_accesses, HighResTimer &timer,
   
   // Get the starting address of the pointer chain.
   uintptr_t *lat_start_ptr = static_cast<uintptr_t *>(buffer);
-  
-  // If sample collection is requested
-  if (latency_samples != nullptr && sample_count > 0) {
-    latency_samples->clear();
-    latency_samples->reserve(sample_count);
-    
-    // Calculate accesses per sample, ensuring at least 1 access per sample
-    size_t accesses_per_sample = (num_accesses >= static_cast<size_t>(sample_count)) 
-                                  ? (num_accesses / static_cast<size_t>(sample_count))
-                                  : 1;
-    
-    double total_duration_ns = 0.0;
-    
-    for (int i = 0; i < sample_count; ++i) {
-      timer.start();
-      memory_latency_chase_asm(lat_start_ptr, accesses_per_sample);
-      double sample_duration_ns = timer.stop_ns();
-      double sample_latency_ns = sample_duration_ns / static_cast<double>(accesses_per_sample);
-      latency_samples->push_back(sample_latency_ns);
-      total_duration_ns += sample_duration_ns;
-    }
-    
-    return total_duration_ns;
-  } else {
-    // Original single measurement behavior
-    timer.start();  // Start timing.
-    // Call external assembly function to chase the pointer chain.
-    memory_latency_chase_asm(lat_start_ptr, num_accesses);
-    // Stop timing, getting result in nanoseconds for latency.
-    double duration_ns = timer.stop_ns();
-    return duration_ns;  // Return total time elapsed in nanoseconds.
-  }
+
+  return run_latency_measurement(lat_start_ptr, num_accesses, timer, latency_samples, sample_count);
 }
 
 /**
@@ -157,7 +180,7 @@ double run_latency_test(void *buffer, size_t num_accesses, HighResTimer &timer,
  * @see setup_latency_chain() for buffer initialization
  */
 double run_cache_latency_test(void *buffer, size_t buffer_size, size_t num_accesses, HighResTimer &timer,
-                              std::vector<double> *latency_samples, int sample_count) {
+                               std::vector<double> *latency_samples, int sample_count) {
   // Early validation: return 0 if no accesses requested
   if (num_accesses == 0) {
     return 0.0;
@@ -165,37 +188,7 @@ double run_cache_latency_test(void *buffer, size_t buffer_size, size_t num_acces
   
   // Get the starting address of the pointer chain.
   uintptr_t *lat_start_ptr = static_cast<uintptr_t *>(buffer);
-  
-  // If sample collection is requested
-  if (latency_samples != nullptr && sample_count > 0) {
-    latency_samples->clear();
-    latency_samples->reserve(sample_count);
-    
-    // Calculate accesses per sample, ensuring at least 1 access per sample
-    size_t accesses_per_sample = (num_accesses >= static_cast<size_t>(sample_count)) 
-                                  ? (num_accesses / static_cast<size_t>(sample_count))
-                                  : 1;
-    
-    double total_duration_ns = 0.0;
-    
-    for (int i = 0; i < sample_count; ++i) {
-      timer.start();
-      memory_latency_chase_asm(lat_start_ptr, accesses_per_sample);
-      double sample_duration_ns = timer.stop_ns();
-      double sample_latency_ns = sample_duration_ns / static_cast<double>(accesses_per_sample);
-      latency_samples->push_back(sample_latency_ns);
-      total_duration_ns += sample_duration_ns;
-    }
-    
-    return total_duration_ns;
-  } else {
-    // Original single measurement behavior
-    timer.start();  // Start timing.
-    // Call external assembly function to chase the pointer chain (same as main latency test).
-    memory_latency_chase_asm(lat_start_ptr, num_accesses);
-    // Stop timing, getting result in nanoseconds for latency.
-    double duration_ns = timer.stop_ns();
-    return duration_ns;  // Return total time elapsed in nanoseconds.
-  }
-}
 
+  (void)buffer_size;
+  return run_latency_measurement(lat_start_ptr, num_accesses, timer, latency_samples, sample_count);
+}

--- a/src/benchmark/parallel_test_framework.h
+++ b/src/benchmark/parallel_test_framework.h
@@ -58,6 +58,62 @@
 // --- Generic Parallel Test Framework ---
 
 /**
+ * @brief Build contiguous per-thread ranges with aligned internal boundaries.
+ *
+ * Produces `num_threads` contiguous ranges that cover [0, size) exactly once.
+ * Internal boundaries are aligned to cache-line boundaries (rounded up) using
+ * `alignment_base` as the pointer reference. This keeps dst chunk starts aligned
+ * for most threads while preserving full byte coverage (no gaps/overlaps).
+ *
+ * @param alignment_base Base pointer used for boundary alignment calculations
+ * @param size Total size of the covered range in bytes
+ * @param num_threads Number of ranges to produce (must be > 0)
+ * @return Vector of boundary offsets of size num_threads + 1
+ */
+inline std::vector<size_t> build_aligned_chunk_boundaries(void* alignment_base, size_t size, int num_threads) {
+  const size_t thread_count = static_cast<size_t>(num_threads);
+  std::vector<size_t> boundaries(thread_count + 1, 0);
+
+  // Start from an even byte partition.
+  size_t offset = 0;
+  const size_t chunk_base_size = size / thread_count;
+  const size_t chunk_remainder = size % thread_count;
+  for (size_t t = 0; t < thread_count; ++t) {
+    const size_t chunk_size = chunk_base_size + (t < chunk_remainder ? 1 : 0);
+    offset += chunk_size;
+    boundaries[t + 1] = offset;
+  }
+
+  // Align internal boundaries while preserving monotonic ordering.
+  char* base_ptr = static_cast<char*>(alignment_base);
+  for (size_t i = 1; i < thread_count; ++i) {
+    char* boundary_ptr = base_ptr + boundaries[i];
+    char* aligned_boundary_ptr = static_cast<char*>(align_ptr_to_cache_line(boundary_ptr));
+    size_t aligned_offset = static_cast<size_t>(aligned_boundary_ptr - base_ptr);
+
+    if (aligned_offset > size) {
+      aligned_offset = size;
+    }
+    if (aligned_offset < boundaries[i - 1]) {
+      aligned_offset = boundaries[i - 1];
+    }
+    boundaries[i] = aligned_offset;
+  }
+
+  boundaries[0] = 0;
+  boundaries[thread_count] = size;
+
+  // Final monotonicity guard after clamping.
+  for (size_t i = 1; i < boundaries.size(); ++i) {
+    if (boundaries[i] < boundaries[i - 1]) {
+      boundaries[i] = boundaries[i - 1];
+    }
+  }
+
+  return boundaries;
+}
+
+/**
  * @brief Run a parallel test with automatic work distribution across threads
  * @tparam WorkFunction Function type for per-thread work (void(void* chunk_start, size_t chunk_size, int iterations))
  * @param buffer Pointer to the memory buffer to operate on
@@ -81,67 +137,34 @@
 template<typename WorkFunction>
 double run_parallel_test(void *buffer, size_t size, int iterations, int num_threads, HighResTimer &timer,
                          WorkFunction work_function, const char *thread_name) {
+  // Early validation: return 0.0 if no work to do or invalid thread count.
+  // This avoids unnecessary setup and prevents division-by-zero in partitioning.
+  if (size == 0 || num_threads <= 0) {
+    return 0.0;
+  }
+
   std::vector<std::thread> threads;
-  threads.reserve(num_threads);  // Pre-allocate vector space for threads.
+  threads.reserve(static_cast<size_t>(num_threads));  // Pre-allocate vector space for threads.
 
   std::mutex start_mutex;
   std::condition_variable start_cv;
   bool start_flag = false;  // Gate so timing starts after threads are ready
 
-  // Divide work among threads (chunks calculated once).
-  size_t offset = 0;
-  size_t chunk_base_size = size / num_threads;
-  size_t chunk_remainder = size % num_threads;
-
-  // Early validation: return 0.0 if no work to do or invalid thread count.
-  // This avoids timer overhead when no meaningful work can be performed.
-  if (size == 0 || num_threads <= 0) {
-    return 0.0;  // No work to do or invalid thread count
-  }
+  // Build contiguous chunk boundaries with aligned internal split points.
+  std::vector<size_t> boundaries = build_aligned_chunk_boundaries(buffer, size, num_threads);
 
   // Launch threads once; each handles its chunk for all iterations.
-  for (int t = 0; t < num_threads; ++t) {
-    // Calculate the exact size for this thread's chunk, adding remainder if needed.
-    size_t original_chunk_size = chunk_base_size + (t < chunk_remainder ? 1 : 0);
-    if (original_chunk_size == 0) continue;  // Avoid launching threads for zero work.
-
-    // Calculate the original end position for this chunk
-    size_t original_chunk_end = offset + original_chunk_size;
-    
-    // Calculate the start address for this thread's chunk.
-    char *unaligned_start = static_cast<char *>(buffer) + offset;
-    // Align chunk_start to cache line boundary to prevent false sharing
-    char *chunk_start = static_cast<char *>(align_ptr_to_cache_line(unaligned_start));
-    
-    // Calculate chunk size to cover the original range [offset, offset + original_chunk_size)
-    // This ensures no gaps: chunk covers from aligned start to original end
-    char *original_end_ptr = static_cast<char *>(buffer) + original_chunk_end;
-    
-    // Check if alignment moved us past the original range
-    // If so, fallback to unaligned start to ensure coverage
-    if (chunk_start >= original_end_ptr) {
-      chunk_start = unaligned_start;
-    }
-    
-    size_t current_chunk_size = original_end_ptr - chunk_start;
-    
-    // Ensure we don't exceed the buffer size
-    char *buffer_end = static_cast<char *>(buffer) + size;
-    if (chunk_start + current_chunk_size > buffer_end) {
-      current_chunk_size = buffer_end - chunk_start;
-    }
-    
-    // Skip if chunk size is zero or negative after alignment adjustments
-    if (current_chunk_size == 0 || chunk_start >= buffer_end) {
-      // Still update offset to prevent infinite loops, but skip thread creation
-      offset = original_chunk_end;
+  char* buffer_start = static_cast<char*>(buffer);
+  for (size_t t = 0; t < static_cast<size_t>(num_threads); ++t) {
+    size_t chunk_start_offset = boundaries[t];
+    size_t chunk_end_offset = boundaries[t + 1];
+    if (chunk_end_offset <= chunk_start_offset) {
       continue;
     }
-    
-    // Capture aligned chunk_start and adjusted chunk_size for the thread
-    char *thread_chunk_start = chunk_start;
-    size_t thread_chunk_size = current_chunk_size;
-    
+
+    char* thread_chunk_start = buffer_start + chunk_start_offset;
+    size_t thread_chunk_size = chunk_end_offset - chunk_start_offset;
+     
     // iterations loop inside thread lambda for re-use (avoids per-iteration creation).
     threads.emplace_back([thread_chunk_start, thread_chunk_size, iterations, &start_mutex, &start_cv,
                           &start_flag, work_function, thread_name]() {
@@ -160,9 +183,6 @@ double run_parallel_test(void *buffer, size_t size, int iterations, int num_thre
       // Execute the work function for this chunk with aligned pointer
       work_function(thread_chunk_start, thread_chunk_size, iterations);
     });
-    
-    // Move the offset for the next thread's chunk using the actual end position
-    offset = original_chunk_end;
   }
 
   // Check if any threads were created. If all chunks were zero after alignment,
@@ -208,76 +228,37 @@ double run_parallel_test(void *buffer, size_t size, int iterations, int num_thre
  */
 template<typename WorkFunction>
 double run_parallel_test_copy(void *dst, void *src, size_t size, int iterations, int num_threads, HighResTimer &timer,
-                               WorkFunction work_function, const char *thread_name) {
+                                WorkFunction work_function, const char *thread_name) {
+  // Early validation: return 0.0 if no work to do or invalid thread count.
+  // This avoids unnecessary setup and prevents division-by-zero in partitioning.
+  if (size == 0 || num_threads <= 0) {
+    return 0.0;
+  }
+
   std::vector<std::thread> threads;
-  threads.reserve(num_threads);  // Pre-allocate vector space for threads.
+  threads.reserve(static_cast<size_t>(num_threads));  // Pre-allocate vector space for threads.
 
   std::mutex start_mutex;
   std::condition_variable start_cv;
   bool start_flag = false;  // Gate so timing starts after threads are ready
 
-  // Divide work among threads (chunks calculated once).
-  size_t offset = 0;
-  size_t chunk_base_size = size / num_threads;
-  size_t chunk_remainder = size % num_threads;
-
-  // Early validation: return 0.0 if no work to do or invalid thread count.
-  // This avoids timer overhead when no meaningful work can be performed.
-  if (size == 0 || num_threads <= 0) {
-    return 0.0;  // No work to do or invalid thread count
-  }
+  // Build contiguous chunk boundaries using destination alignment for false-sharing mitigation.
+  std::vector<size_t> boundaries = build_aligned_chunk_boundaries(dst, size, num_threads);
 
   // Launch threads once; each handles its chunk for all iterations.
-  for (int t = 0; t < num_threads; ++t) {
-    // Calculate the exact size for this thread's chunk, adding remainder if needed.
-    size_t original_chunk_size = chunk_base_size + (t < chunk_remainder ? 1 : 0);
-    if (original_chunk_size == 0) continue;  // Avoid launching threads for zero work.
-
-    // Calculate the original end position for this chunk
-    size_t original_chunk_end = offset + original_chunk_size;
-    
-    // Calculate unaligned start positions
-    char *dst_unaligned_start = static_cast<char *>(dst) + offset;
-    char *src_unaligned_start = static_cast<char *>(src) + offset;
-    
-    // Align dst to cache line boundary to prevent false sharing
-    char *dst_chunk = static_cast<char *>(align_ptr_to_cache_line(dst_unaligned_start));
-    
-    // Calculate chunk size to cover the original range [offset, offset + original_chunk_size)
-    // This ensures no gaps: chunk covers from aligned start to original end
-    char *dst_original_end = static_cast<char *>(dst) + original_chunk_end;
-    
-    // Check if alignment moved us past the original range
-    // If so, fallback to unaligned start to ensure coverage
-    if (dst_chunk >= dst_original_end) {
-      dst_chunk = dst_unaligned_start;
-    }
-    
-    // Maintain src/dst correspondence by applying the same alignment offset
-    // This ensures data integrity: src[i] always maps to dst[i]
-    size_t alignment_offset = dst_chunk - dst_unaligned_start;
-    char *src_chunk = src_unaligned_start + alignment_offset;
-    
-    size_t current_chunk_size = dst_original_end - dst_chunk;
-    
-    // Ensure we don't exceed the buffer size
-    char *dst_end = static_cast<char *>(dst) + size;
-    if (dst_chunk + current_chunk_size > dst_end) {
-      current_chunk_size = dst_end - dst_chunk;
-    }
-    
-    // Skip if chunk size is zero or negative after alignment adjustments
-    if (current_chunk_size == 0 || dst_chunk >= dst_end) {
-      // Still update offset to prevent infinite loops, but skip thread creation
-      offset = original_chunk_end;
+  char* dst_start = static_cast<char*>(dst);
+  char* src_start = static_cast<char*>(src);
+  for (size_t t = 0; t < static_cast<size_t>(num_threads); ++t) {
+    size_t chunk_start_offset = boundaries[t];
+    size_t chunk_end_offset = boundaries[t + 1];
+    if (chunk_end_offset <= chunk_start_offset) {
       continue;
     }
-    
-    // Capture aligned chunk pointers and adjusted chunk_size for the thread
-    char *thread_dst_chunk = dst_chunk;
-    char *thread_src_chunk = src_chunk;
-    size_t thread_chunk_size = current_chunk_size;
-    
+
+    char* thread_dst_chunk = dst_start + chunk_start_offset;
+    char* thread_src_chunk = src_start + chunk_start_offset;
+    size_t thread_chunk_size = chunk_end_offset - chunk_start_offset;
+     
     // iterations loop inside thread lambda for re-use (avoids per-iteration creation).
     threads.emplace_back([thread_dst_chunk, thread_src_chunk, thread_chunk_size, iterations, &start_mutex, &start_cv,
                           &start_flag, work_function, thread_name]() {
@@ -296,9 +277,6 @@ double run_parallel_test_copy(void *dst, void *src, size_t size, int iterations,
       // Execute the work function for this chunk with aligned pointers
       work_function(thread_dst_chunk, thread_src_chunk, thread_chunk_size, iterations);
     });
-    
-    // Move the offset for the next thread's chunk using the actual end position
-    offset = original_chunk_end;
   }
 
   // Check if any threads were created. If all chunks were zero after alignment,
@@ -320,4 +298,3 @@ double run_parallel_test_copy(void *dst, void *src, size_t size, int iterations,
 }
 
 #endif // PARALLEL_TEST_FRAMEWORK_H
-

--- a/src/core/config/config_validator.cpp
+++ b/src/core/config/config_validator.cpp
@@ -99,22 +99,29 @@ int validate_config(BenchmarkConfig& config) {
   // Calculate memory limit
   unsigned long available_mem_mb = get_available_memory_mb();
   unsigned long max_allowed_mb_per_buffer = 0;
+  unsigned long required_main_buffers = 3;  // Default mode: src + dst + lat
+
+  if (config.only_latency) {
+    required_main_buffers = 1;  // Latency-only mode: lat
+  } else if (config.only_bandwidth || config.run_patterns) {
+    required_main_buffers = 2;  // Bandwidth/pattern mode: src + dst
+  }
 
   if (available_mem_mb > 0) {
     config.max_total_allowed_mb = static_cast<unsigned long>(available_mem_mb * Constants::MEMORY_LIMIT_FACTOR);
-    // Divide by 3 to account for the 3 main buffers: src, dst, and lat.
+    // Divide by mode-specific main buffer count.
     // Note: This per-buffer calculation does NOT include cache buffers (L1, L2, custom)
     // and their bandwidth counterparts. The total memory check in buffer_manager.cpp
     // is necessary to ensure all buffers (main + cache) fit within max_total_allowed_mb.
-    max_allowed_mb_per_buffer = config.max_total_allowed_mb / 3;
+    max_allowed_mb_per_buffer = config.max_total_allowed_mb / required_main_buffers;
   } else {
     std::cerr << Messages::warning_prefix() << Messages::warning_cannot_get_memory() << std::endl;
     config.max_total_allowed_mb = Constants::FALLBACK_TOTAL_LIMIT_MB;
-    // Divide by 3 to account for the 3 main buffers: src, dst, and lat.
+    // Divide by mode-specific main buffer count.
     // Note: This per-buffer calculation does NOT include cache buffers (L1, L2, custom)
     // and their bandwidth counterparts. The total memory check in buffer_manager.cpp
     // is necessary to ensure all buffers (main + cache) fit within max_total_allowed_mb.
-    max_allowed_mb_per_buffer = config.max_total_allowed_mb / 3;
+    max_allowed_mb_per_buffer = config.max_total_allowed_mb / required_main_buffers;
     std::cout << Messages::info_setting_max_fallback(max_allowed_mb_per_buffer) << std::endl;
   }
   
@@ -123,24 +130,14 @@ int validate_config(BenchmarkConfig& config) {
     max_allowed_mb_per_buffer = Constants::MINIMUM_LIMIT_MB_PER_BUFFER;
   }
 
-  // Validate and cap buffer size (only if not latency-only, or if latency-only but buffer_size is needed)
-  // For latency-only mode, we still need buffer_size for main memory latency test, but we use default
-  if (!config.only_latency) {
-    // For bandwidth tests, validate and cap buffer size
-    if (config.buffer_size_mb > max_allowed_mb_per_buffer) {
-      std::cerr << Messages::warning_prefix() << Messages::warning_buffer_size_exceeds_limit(config.buffer_size_mb, max_allowed_mb_per_buffer) << std::endl;
-      config.buffer_size_mb = max_allowed_mb_per_buffer;
-    }
-  } else {
-    // For latency-only, we still need a buffer for main memory latency test
-    // Use default if not set, but don't cap it (latency test uses less memory)
-    if (config.buffer_size_mb == 0) {
-      config.buffer_size_mb = Constants::DEFAULT_BUFFER_SIZE_MB;
-    }
-    if (config.buffer_size_mb > max_allowed_mb_per_buffer) {
-      std::cerr << Messages::warning_prefix() << Messages::warning_buffer_size_exceeds_limit(config.buffer_size_mb, max_allowed_mb_per_buffer) << std::endl;
-      config.buffer_size_mb = max_allowed_mb_per_buffer;
-    }
+  // Validate and cap buffer size.
+  // In latency-only mode, use default if unset before applying cap.
+  if (config.only_latency && config.buffer_size_mb == 0) {
+    config.buffer_size_mb = Constants::DEFAULT_BUFFER_SIZE_MB;
+  }
+  if (config.buffer_size_mb > max_allowed_mb_per_buffer) {
+    std::cerr << Messages::warning_prefix() << Messages::warning_buffer_size_exceeds_limit(config.buffer_size_mb, max_allowed_mb_per_buffer) << std::endl;
+    config.buffer_size_mb = max_allowed_mb_per_buffer;
   }
 
   // Calculate final buffer size in bytes
@@ -163,4 +160,3 @@ int validate_config(BenchmarkConfig& config) {
 
   return EXIT_SUCCESS;  // All validations passed
 }
-

--- a/src/core/config/version.h
+++ b/src/core/config/version.h
@@ -29,7 +29,7 @@
  * @def SOFTVERSION
  * @brief Software version number (semantic versioning format as string)
  */
-#define SOFTVERSION "0.52.7"
+#define SOFTVERSION "0.52.8"
 
 #endif // VERSION_H
 

--- a/src/core/memory/buffer_allocator.cpp
+++ b/src/core/memory/buffer_allocator.cpp
@@ -120,6 +120,11 @@ int allocate_all_buffers(const BenchmarkConfig& config, BenchmarkBuffers& buffer
   if (!config.only_bandwidth && !config.run_patterns) {
     // Need lat buffer for latency tests (but not for pattern benchmarks, which are bandwidth-only)
     if (config.buffer_size > 0) {
+      // Error: Check addition overflow when accumulating total memory
+      if (total_memory > std::numeric_limits<size_t>::max() - config.buffer_size) {
+        std::cerr << Messages::error_prefix() << Messages::error_total_memory_overflow() << std::endl;
+        return EXIT_FAILURE;  // Return code: arithmetic overflow error
+      }
       total_memory += config.buffer_size;  // lat
     }
   }
@@ -202,9 +207,9 @@ int allocate_all_buffers(const BenchmarkConfig& config, BenchmarkBuffers& buffer
   }
   
   // Validate total memory requirement against availability limit.
-  // This check is necessary because the per-buffer limit calculation in config.cpp
-  // (max_total_allowed_mb / 3) only accounts for the 3 main buffers (src, dst, lat)
-  // and does not include cache buffers (L1, L2, custom) and their bandwidth counterparts.
+  // This check is necessary because per-buffer limit calculation in config_validator.cpp
+  // accounts for main buffers only (mode-aware: 1/2/3 buffers) and does not include
+  // cache buffers (L1, L2, custom) and their bandwidth counterparts.
   // This ensures the combined memory usage of all buffers stays within the total limit.
   if (config.max_total_allowed_mb > 0) {
     // Error: Total memory requirement exceeds system limit
@@ -390,4 +395,3 @@ int allocate_all_buffers(const BenchmarkConfig& config, BenchmarkBuffers& buffer
 
   return EXIT_SUCCESS;  // All buffers allocated successfully
 }
-

--- a/src/output/console/messages/program_messages.cpp
+++ b/src/output/console/messages/program_messages.cpp
@@ -51,7 +51,7 @@ const std::string& msg_running_pattern_benchmarks() {
 std::string usage_header(const std::string& version) {
   std::ostringstream oss;
   oss << "Copyright 2025-2026 Timo Heimonen <timo.heimonen@proton.me>\n"
-      << "Version: " << version << " by Timo Heimonen <timo.heimonen@proton.me>\n"
+      << "Version: " << version << "\n"
       << "License: GNU GPL v3. See <https://www.gnu.org/licenses/>\n"
       << "This program is free software: you can redistribute it and/or modify\n"
       << "it under the terms of the GNU General Public License as published by\n"
@@ -109,4 +109,3 @@ std::string usage_example(const std::string& prog_name) {
 }
 
 } // namespace Messages
-

--- a/tests/test_benchmark_executor.cpp
+++ b/tests/test_benchmark_executor.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <unistd.h>
+
+#include "benchmark/benchmark_executor.h"
+#include "benchmark/benchmark_runner.h"
+#include "benchmark/benchmark_tests.h"
+#include "core/config/config.h"
+#include "core/config/constants.h"
+#include "core/memory/buffer_manager.h"
+#include "core/memory/memory_utils.h"
+#include "core/system/system_info.h"
+#include "core/timing/timer.h"
+
+namespace {
+
+BenchmarkConfig build_base_config() {
+  BenchmarkConfig config;
+
+  config.cpu_name = get_processor_name();
+  config.perf_cores = get_performance_cores();
+  config.eff_cores = get_efficiency_cores();
+  config.num_threads = get_total_logical_cores();
+  config.l1_cache_size = get_l1_cache_size();
+  config.l2_cache_size = get_l2_cache_size();
+
+  config.buffer_size = static_cast<size_t>(getpagesize());
+  config.buffer_size_mb = 1;
+  config.iterations = 1;
+  config.loop_count = 1;
+  config.use_custom_cache_size = false;
+
+  calculate_buffer_sizes(config);
+  calculate_access_counts(config);
+  return config;
+}
+
+}  // namespace
+
+TEST(BenchmarkExecutorTest, WriteTestCoversEntireBufferForUnevenThreadSplits) {
+  const size_t buffer_size = (1024 * 1024) + 123;
+  std::vector<unsigned char> buffer(buffer_size, 0xAB);
+
+  auto timer_opt = HighResTimer::create();
+  ASSERT_TRUE(timer_opt.has_value());
+
+  double duration = run_write_test(buffer.data(), buffer.size(), 1, 10, *timer_opt);
+  EXPECT_GT(duration, 0.0);
+
+  bool all_zero = std::all_of(buffer.begin(), buffer.end(), [](unsigned char value) {
+    return value == 0;
+  });
+  EXPECT_TRUE(all_zero);
+}
+
+TEST(BenchmarkExecutorTest, WriteTestReturnsZeroForInvalidThreadCounts) {
+  std::vector<unsigned char> buffer(4096, 0xCD);
+
+  auto timer_opt = HighResTimer::create();
+  ASSERT_TRUE(timer_opt.has_value());
+
+  double zero_thread_duration = run_write_test(buffer.data(), buffer.size(), 1, 0, *timer_opt);
+  double negative_thread_duration = run_write_test(buffer.data(), buffer.size(), 1, -1, *timer_opt);
+
+  EXPECT_EQ(zero_thread_duration, 0.0);
+  EXPECT_EQ(negative_thread_duration, 0.0);
+
+  bool unchanged = std::all_of(buffer.begin(), buffer.end(), [](unsigned char value) {
+    return value == 0xCD;
+  });
+  EXPECT_TRUE(unchanged);
+}
+
+TEST(BenchmarkExecutorTest, LatencySamplingClampsToAccessCount) {
+  const size_t buffer_size = static_cast<size_t>(getpagesize());
+  std::vector<unsigned char> buffer(buffer_size, 0);
+
+  ASSERT_EQ(setup_latency_chain(buffer.data(), buffer_size, Constants::LATENCY_STRIDE_BYTES), EXIT_SUCCESS);
+
+  auto timer_opt = HighResTimer::create();
+  ASSERT_TRUE(timer_opt.has_value());
+
+  const size_t num_accesses = 7;
+  const int requested_samples = 100;
+  std::vector<double> samples;
+
+  double total_duration_ns = run_latency_test(buffer.data(), num_accesses, *timer_opt, &samples, requested_samples);
+  EXPECT_GE(total_duration_ns, 0.0);
+  EXPECT_FALSE(std::isnan(total_duration_ns));
+  EXPECT_FALSE(std::isinf(total_duration_ns));
+  EXPECT_EQ(samples.size(), num_accesses);
+
+  for (double sample : samples) {
+    EXPECT_GE(sample, 0.0);
+    EXPECT_FALSE(std::isnan(sample));
+    EXPECT_FALSE(std::isinf(sample));
+  }
+}
+
+TEST(BenchmarkExecutorTest, MainMemoryLatencyCollectsSamplesWhenConfigured) {
+  BenchmarkConfig config = build_base_config();
+  config.only_latency = true;
+  config.latency_sample_count = 17;
+
+  BenchmarkBuffers buffers;
+  ASSERT_EQ(allocate_all_buffers(config, buffers), EXIT_SUCCESS);
+  ASSERT_EQ(initialize_all_buffers(buffers, config), EXIT_SUCCESS);
+
+  auto timer_opt = HighResTimer::create();
+  ASSERT_TRUE(timer_opt.has_value());
+
+  TimingResults timings;
+  BenchmarkResults results;
+  run_main_memory_latency_test(buffers, config, timings, results, *timer_opt);
+
+  EXPECT_GT(timings.total_lat_time_ns, 0.0);
+  EXPECT_EQ(results.latency_samples.size(), static_cast<size_t>(config.latency_sample_count));
+}

--- a/tests/test_buffer_manager.cpp
+++ b/tests/test_buffer_manager.cpp
@@ -19,6 +19,7 @@
 #include "core/config/constants.h"
 #include "utils/benchmark.h"  // Declares system_info functions
 #include <cstdlib>
+#include <limits>
 
 // Test buffer allocation with valid config
 TEST(BufferManagerTest, AllocateAllBuffersValid) {
@@ -316,3 +317,20 @@ TEST(BufferManagerTest, AllocateAllBuffersPartialFailure) {
   EXPECT_EQ(buffers.l2_buffer(), nullptr);
 }
 
+// Test overflow check when adding main latency buffer to total memory
+TEST(BufferManagerTest, AllocateAllBuffersMainLatencyAdditionOverflow) {
+  BenchmarkConfig config;
+  config.buffer_size = std::numeric_limits<size_t>::max() / 2;
+  config.only_latency = false;
+  config.only_bandwidth = false;
+  config.run_patterns = false;
+
+  testing::internal::CaptureStderr();
+  BenchmarkBuffers buffers;
+  int result = allocate_all_buffers(config, buffers);
+  std::string error_output = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, EXIT_FAILURE);
+  EXPECT_NE(error_output.find("Error: "), std::string::npos);
+  EXPECT_NE(error_output.find("Total memory requirement would overflow"), std::string::npos);
+}

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -17,6 +17,7 @@
 #include "core/config/config.h"
 #include "core/config/constants.h"
 #include <cstdlib>
+#include <limits>
 
 // Test default configuration values
 TEST(ConfigTest, DefaultValues) {
@@ -167,3 +168,50 @@ TEST(ConfigTest, AccessCountScaling) {
   EXPECT_LT(config1.lat_num_accesses, config2.lat_num_accesses);
 }
 
+// Test validate_config rejects mutually exclusive flags
+TEST(ConfigTest, ValidateConfigRejectsOnlyBandwidthAndOnlyLatency) {
+  BenchmarkConfig config;
+  config.only_bandwidth = true;
+  config.only_latency = true;
+
+  int result = validate_config(config);
+  EXPECT_EQ(result, EXIT_FAILURE);
+}
+
+// Test validate_config rejects only-flags with pattern mode
+TEST(ConfigTest, ValidateConfigRejectsOnlyFlagsWithPatterns) {
+  BenchmarkConfig config;
+  config.run_patterns = true;
+  config.only_bandwidth = true;
+
+  int result = validate_config(config);
+  EXPECT_EQ(result, EXIT_FAILURE);
+}
+
+// Test mode-aware per-buffer capping based on required main buffer count
+TEST(ConfigTest, ValidateConfigModeAwareBufferCap) {
+  auto expected_cap = [](const BenchmarkConfig& cfg, unsigned long required_main_buffers) {
+    unsigned long cap = cfg.max_total_allowed_mb / required_main_buffers;
+    if (cap < Constants::MINIMUM_LIMIT_MB_PER_BUFFER) {
+      cap = Constants::MINIMUM_LIMIT_MB_PER_BUFFER;
+    }
+    return cap;
+  };
+
+  BenchmarkConfig full;
+  full.buffer_size_mb = std::numeric_limits<unsigned long>::max();
+  EXPECT_EQ(validate_config(full), EXIT_SUCCESS);
+  EXPECT_EQ(full.buffer_size_mb, expected_cap(full, 3));
+
+  BenchmarkConfig bw_only;
+  bw_only.only_bandwidth = true;
+  bw_only.buffer_size_mb = std::numeric_limits<unsigned long>::max();
+  EXPECT_EQ(validate_config(bw_only), EXIT_SUCCESS);
+  EXPECT_EQ(bw_only.buffer_size_mb, expected_cap(bw_only, 2));
+
+  BenchmarkConfig lat_only;
+  lat_only.only_latency = true;
+  lat_only.buffer_size_mb = std::numeric_limits<unsigned long>::max();
+  EXPECT_EQ(validate_config(lat_only), EXIT_SUCCESS);
+  EXPECT_EQ(lat_only.buffer_size_mb, expected_cap(lat_only, 1));
+}


### PR DESCRIPTION
## [0.52.8] - 2026-03-07

### Fixed
- **Zero-access latency chase safety**: Fixed `memory_latency_chase_asm` to return immediately when `count == 0`, preventing an unnecessary dereference when no pointer-chasing accesses are requested.
- **Unsigned loop termination in latency chase**: Fixed loop branch conditions in `memory_latency_chase_asm` to use counter-based `b.ne` termination, ensuring correct behavior for full `size_t` ranges.
- **Latency measurement overhead in pointer chase kernel**: Removed pre-touch and barrier instructions (`ldr` preload, `dsb/isb`, and `dmb` fences) from `memory_latency_chase_asm` to avoid adding non-chase overhead to latency measurements.
- **`size_t`-safe branch/cleanup fixes across ARM64 bandwidth kernels**: Unified loop/cleanup/byte-tail control flow in forward, reverse, strided, and random read/write/copy kernels to use unsigned or zero/non-zero termination semantics (`b.hs`/`b.lo`/`b.ls`, `cbz`, `b.ne`), and fixed reverse cleanup exit direction plus reverse copy byte-tail pointer initialization for correct full-range behavior.
- **Mode-aware memory cap validation for `-only-bandwidth` / `-only-latency` / `-patterns`**: Updated `validate_config()` to compute per-buffer limits using the active main-buffer count (1/2/3) instead of always dividing by 3, preventing unnecessary buffer-size capping in reduced-buffer modes while keeping total-memory safeguards intact.
- **Main-buffer total-memory overflow guard in allocator**: Added missing checked-add overflow validation when including the main latency buffer in `allocate_all_buffers()` total-memory accounting, and added a targeted unit test to lock in the overflow failure path.