### PR TITLE
Version 0.53.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
   - **CLI help text extended for standalone core-to-core mode**: `-h/--help` now documents `-analyze-core2core` and its allowed option set.
+  - **Core-to-core handoff loop uses dedicated ARM64 assembly kernels**: Standalone `-analyze-core2core` now executes initiator/responder token ping-pong rounds through dedicated assembly routines, while keeping the existing mode interface, reporting, and JSON output structure.
   - **Refactored standalone TLB analysis module into smaller units**: Split previous `src/benchmark/analysis.cpp` into focused files: `src/benchmark/tlb_analysis.cpp` (orchestration), `src/benchmark/tlb_boundary_detector.cpp` (boundary detection and confidence logic), and `src/benchmark/tlb_analysis_json.cpp` (JSON serialization).
   - **Renamed TLB analysis interface/header**: Renamed `src/benchmark/analysis.h` to `src/benchmark/tlb_analysis.h` and updated includes/references accordingly (`main.cpp`, tests, and docs).
   - **Build wiring updated for new TLB analysis files**: Updated benchmark source list in `Makefile` to compile/link the new `tlb_analysis*` and `tlb_boundary_detector` units.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.53.6] - 2026-03-12
+## [0.53.6] - 2026-xx-xx
+
+### Added
+  - **Standalone core-to-core latency analysis mode (`-analyze-core2core`)**: Added a dedicated two-thread cache-line handoff benchmark mode that runs outside standard benchmark orchestration and supports optional `-output <file>`, `-count <count>`, and `-latency-samples <count>`.
+  - **Core-to-core scenario reporting with scheduler hints**: New mode executes `no_affinity_hint`, `same_affinity_tag`, and `different_affinity_tags` scenarios, reports round-trip latency, one-way estimate, sample distribution statistics (P50/P90/P95/P99/stddev/min/max), and per-thread QoS/affinity hint status.
+  - **Core-to-core JSON export**: Added mode-specific JSON payload under `core_to_core_latency` including loop values, sample distributions, computed statistics, and thread-hint application results.
 
 ### Changed
+  - **CLI help text extended for standalone core-to-core mode**: `-h/--help` now documents `-analyze-core2core` and its allowed option set.
   - **Refactored standalone TLB analysis module into smaller units**: Split previous `src/benchmark/analysis.cpp` into focused files: `src/benchmark/tlb_analysis.cpp` (orchestration), `src/benchmark/tlb_boundary_detector.cpp` (boundary detection and confidence logic), and `src/benchmark/tlb_analysis_json.cpp` (JSON serialization).
   - **Renamed TLB analysis interface/header**: Renamed `src/benchmark/analysis.h` to `src/benchmark/tlb_analysis.h` and updated includes/references accordingly (`main.cpp`, tests, and docs).
   - **Build wiring updated for new TLB analysis files**: Updated benchmark source list in `Makefile` to compile/link the new `tlb_analysis*` and `tlb_boundary_detector` units.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.53.6] - 2026-xx-xx
+## [0.53.6] - 2026-03-13
 
 ### Added
   - **Standalone core-to-core latency analysis mode (`-analyze-core2core`)**: Added a dedicated two-thread cache-line handoff benchmark mode that runs outside standard benchmark orchestration and supports optional `-output <file>`, `-count <count>`, and `-latency-samples <count>`.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -200,6 +200,15 @@ Pattern mode (`-patterns`) measures bandwidth sensitivity across:
 - Separately computes page-walk penalty as `P50(512MB) - P50(effective baseline locality)` when analysis buffer is at least `512MB`
 - Detailed methodology and JSON contract: `TLB_ANALYSIS_WHITEPAPER.md`
 
+#### `-analyze-core2core`
+
+- Runs standalone two-thread cache-line handoff (ping-pong) mode only
+- Can be combined only with optional `-output <file>`, `-count <count>`, and `-latency-samples <count>`
+- Executes three scheduler-hint scenarios: `no_affinity_hint`, `same_affinity_tag`, and `different_affinity_tags`
+- Reports round-trip latency, one-way estimate (`round_trip / 2`), and sample distribution stats (P50/P90/P95/P99/stddev/min/max)
+- Includes per-thread QoS/affinity hint status in console and JSON output
+- Notes explicitly that macOS user-space cannot hard-pin exact core IDs
+
 ### Latency-specific controls
 
 #### `-latency-samples <count>`
@@ -212,7 +221,7 @@ Pattern mode (`-patterns`) measures bandwidth sensitivity across:
 #### `-latency-stride-bytes <bytes>`
 
 - Pointer-chain stride for latency tests
-- Default: `136`
+- Default: `64`
 - Must be `> 0`
 - Must be a multiple of pointer size (`8` bytes on Apple Silicon)
 - Use smaller values (for example `64`) to increase same-page cache-line activity and reduce TLB sensitivity
@@ -284,6 +293,12 @@ Pattern mode (`-patterns`) measures bandwidth sensitivity across:
 
 # Standalone TLB analysis with custom stride
 ./memory_benchmark -analyze-tlb -latency-stride-bytes 128 -output tlb_analysis_stride128.json
+
+# Standalone core-to-core handoff analysis
+./memory_benchmark -analyze-core2core
+
+# Standalone core-to-core analysis with deeper sampling + JSON
+./memory_benchmark -analyze-core2core -count 5 -latency-samples 2000 -output core2core.json
 ```
 
 ### Invalid combinations
@@ -306,6 +321,9 @@ Pattern mode (`-patterns`) measures bandwidth sensitivity across:
 
 # invalid: analyze-tlb with unsupported extra option
 ./memory_benchmark -analyze-tlb -buffersize 1024
+
+# invalid: analyze-core2core with unsupported extra option
+./memory_benchmark -analyze-core2core -threads 4
 ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,10 @@ ALL_CPP_SRCS = $(CPP_SRCS_ROOT) $(CPP_SRCS_SRC_FULL) $(CPP_SRCS_BENCHMARK_FULL) 
 
 # Assembly source files (in src/asm)
 ASM_SRCS = src/asm/memory_copy.s src/asm/memory_read.s src/asm/memory_write.s src/asm/memory_latency.s \
-           src/asm/memory_read_reverse.s src/asm/memory_write_reverse.s src/asm/memory_copy_reverse.s \
-           src/asm/memory_read_strided.s src/asm/memory_write_strided.s src/asm/memory_copy_strided.s \
-           src/asm/memory_read_random.s src/asm/memory_write_random.s src/asm/memory_copy_random.s
+            src/asm/memory_read_reverse.s src/asm/memory_write_reverse.s src/asm/memory_copy_reverse.s \
+            src/asm/memory_read_strided.s src/asm/memory_write_strided.s src/asm/memory_copy_strided.s \
+            src/asm/memory_read_random.s src/asm/memory_write_random.s src/asm/memory_copy_random.s \
+            src/asm/core_to_core_latency.s
 
 # Object files (derived from source files, maintaining directory structure)
 # main.cpp -> main.o

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ CPP_SRCS_CORE_MEMORY = core/memory/buffer_allocator.cpp core/memory/buffer_initi
 CPP_SRCS_CORE_SYSTEM = core/system/system_info.cpp
 CPP_SRCS_CORE_TIMING = core/timing/timer.cpp
 CPP_SRCS_OUTPUT_CONSOLE = output/console/output_printer.cpp output/console/statistics.cpp
-CPP_SRCS_OUTPUT_CONSOLE_MESSAGES = output/console/messages/error_messages.cpp output/console/messages/warning_messages.cpp output/console/messages/info_messages.cpp output/console/messages/program_messages.cpp output/console/messages/config_messages.cpp output/console/messages/cache_messages.cpp output/console/messages/results_messages.cpp output/console/messages/statistics_messages.cpp output/console/messages/pattern_messages.cpp
+CPP_SRCS_OUTPUT_CONSOLE_MESSAGES = output/console/messages/error_messages.cpp output/console/messages/warning_messages.cpp output/console/messages/info_messages.cpp output/console/messages/program_messages.cpp output/console/messages/core_to_core_messages.cpp output/console/messages/config_messages.cpp output/console/messages/cache_messages.cpp output/console/messages/results_messages.cpp output/console/messages/statistics_messages.cpp output/console/messages/pattern_messages.cpp
 CPP_SRCS_UTILS = utils/utils.cpp utils/json_utils.cpp
 CPP_SRCS_SRC = $(CPP_SRCS_CORE_CONFIG) $(CPP_SRCS_CORE_MEMORY) $(CPP_SRCS_CORE_SYSTEM) $(CPP_SRCS_CORE_TIMING) $(CPP_SRCS_OUTPUT_CONSOLE) $(CPP_SRCS_OUTPUT_CONSOLE_MESSAGES) $(CPP_SRCS_UTILS)
 # Files in the src/benchmark subdirectory
-CPP_SRCS_BENCHMARK = bandwidth_tests.cpp latency_tests.cpp benchmark_runner.cpp benchmark_executor.cpp benchmark_results.cpp benchmark_statistics_collector.cpp tlb_analysis.cpp tlb_boundary_detector.cpp tlb_analysis_json.cpp
+CPP_SRCS_BENCHMARK = bandwidth_tests.cpp latency_tests.cpp benchmark_runner.cpp benchmark_executor.cpp benchmark_results.cpp benchmark_statistics_collector.cpp tlb_analysis.cpp tlb_boundary_detector.cpp tlb_analysis_json.cpp core_to_core_latency_cli.cpp core_to_core_latency_runner.cpp core_to_core_latency_json.cpp
 # Files in the src/warmup subdirectory
 CPP_SRCS_WARMUP = basic_warmup.cpp latency_warmup.cpp cache_warmup.cpp pattern_warmup.cpp
 # Files in the src/output/json/json_output subdirectory

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ caffeinate -i -d ./memory_benchmark -count 10 -buffersize 1024
 - **`-only-bandwidth`**: Runs bandwidth paths only (`-patterns`, `-cache-size`, and `-latency-samples` are not allowed in this mode).
 - **`-only-latency`**: Runs latency paths only (`-patterns` and `-iterations` are not allowed in this mode).
 - **`-analyze-tlb`**: Runs standalone TLB analysis mode; only optional `-output <file>` and `-latency-stride-bytes <bytes>` may be combined with it.
+- **`-analyze-core2core`**: Runs standalone core-to-core cache-line handoff analysis mode; only optional `-output <file>`, `-count <count>`, and `-latency-samples <count>` may be combined with it.
 
 Latency-specific disable controls in `-only-latency`:
 
@@ -123,8 +124,9 @@ Latency-specific disable controls in `-only-latency`:
 - `-threads <count>`: Bandwidth thread count (latency tests remain single-threaded).
 - `-cache-size <KB>`: Custom cache target. Non-zero range is `16` to `1048576` KB (1 GB).
 - `-analyze-tlb`: Standalone TLB-boundary detection benchmark (`1024/512/256 MB` fallback buffer selection), sweeping locality windows from `max(16 KB, 2*stride)` to `256 MB` (plus optional `512 MB` page-walk comparison when buffer is at least `512 MB`). Supports optional `-latency-stride-bytes <bytes>` and defaults to normal latency stride default.
+- `-analyze-core2core`: Standalone two-thread cache-line ping-pong benchmark for coherence handoff latency, with three scheduler-hint scenarios (`no_affinity_hint`, `same_affinity_tag`, `different_affinity_tags`). Reports round-trip and one-way-estimate latency plus percentiles.
 - `-latency-samples <count>`: Samples per latency test (default `1000`).
-- `-latency-stride-bytes <bytes>`: Pointer-chain stride for latency tests (default `136`; must be > 0 and pointer-size aligned).
+- `-latency-stride-bytes <bytes>`: Pointer-chain stride for latency tests (default `64`; must be > 0 and pointer-size aligned).
 - `-latency-tlb-locality-kb <KB>`: Pointer-chain locality window (default `16`; `0` = global random chain; non-zero values must be page-size multiples). If omitted, regular main-memory latency output also includes an automatic TLB comparison (`16 KB` hit-biased vs `0` miss-biased) and estimated page-walk penalty.
 - `-non-cacheable`: Best-effort cache-discouraging hints (not true uncached memory).
 - `-output <file>`: Save JSON output.
@@ -184,6 +186,18 @@ Standalone TLB analysis with custom stride:
 
 ```bash
 ./memory_benchmark -analyze-tlb -latency-stride-bytes 128 -output tlb_analysis_stride128.json
+```
+
+Standalone core-to-core handoff analysis:
+
+```bash
+./memory_benchmark -analyze-core2core
+```
+
+Standalone core-to-core handoff analysis with JSON export and custom sample depth:
+
+```bash
+./memory_benchmark -analyze-core2core -count 5 -latency-samples 2000 -output core2core.json
 ```
 
 ## Output Overview

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -33,6 +33,9 @@ The tool is designed and tuned for Apple Silicon execution characteristics (cach
 
 Main orchestration (`main.cpp`) follows this pipeline:
 
+Standalone modes (`-analyze-tlb`, `-analyze-core2core`) are dispatched early and use dedicated runners.
+The pipeline below applies to standard/pattern benchmark execution.
+
 1. Create high-resolution total-execution timer.
 2. Parse CLI arguments into `BenchmarkConfig` (`parse_arguments`).
 3. Validate configuration (`validate_config`).
@@ -61,6 +64,9 @@ Configuration state is represented by `BenchmarkConfig` (`src/core/config/config
 
 - Main options: buffer size MB, iterations, loop count, output path, threads.
 - Mode flags: `run_patterns`, `only_bandwidth`, `only_latency`.
+- Standalone analysis flags are handled outside `BenchmarkConfig` orchestration flow:
+  - `-analyze-tlb`
+  - `-analyze-core2core`
 - Cache behavior: auto L1/L2 or user-provided `-cache-size`.
 - Latency sampling: `latency_sample_count`.
 - TLB-locality control for latency chain construction:
@@ -84,6 +90,7 @@ Configuration state is represented by `BenchmarkConfig` (`src/core/config/config
   - Second pass parses remaining options.
 - Parser may throw internally (`std::stoll`/validation) but converts to return-code failures at function boundary.
 - Help (`-h`, `--help`) prints usage and exits successfully.
+- `-analyze-core2core` uses dedicated mode parsing (outside `argument_parser.cpp`) and only allows optional `-output`, `-count`, and `-latency-samples`.
 
 ### 5.2 Validation behavior (`config_validator.cpp`)
 

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,7 @@
 #include "core/config/config.h"
 #include "core/memory/buffer_manager.h"
 #include "benchmark/benchmark_runner.h"
+#include "benchmark/core_to_core_latency.h"
 #include "benchmark/tlb_analysis.h"
 #include "output/console/messages.h"
 #include "core/config/constants.h"
@@ -80,6 +81,12 @@
  * @see run_all_pattern_benchmarks() for pattern benchmark execution
  */
 int main(int argc, char *argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "-analyze-core2core") {
+      return run_core_to_core_latency_mode(argc, argv);
+    }
+  }
+
   // Start total execution timer
   auto timer_opt = HighResTimer::create();
   if (!timer_opt) {

--- a/src/asm/asm_functions.h
+++ b/src/asm/asm_functions.h
@@ -66,7 +66,31 @@ extern "C" {
      * @return Final pointer after chasing count links
      */
     uintptr_t* memory_latency_chase_asm(uintptr_t* start_pointer, size_t count);
-    
+
+    /**
+     * @brief Core-to-core initiator ping-pong loop (assembly)
+     * @param turn_ptr Shared turn token pointer
+     * @param round_trips Number of round trips to execute
+     * @param initiator_turn Token value owned by initiator
+     * @param responder_turn Token value owned by responder
+     */
+    void core_to_core_initiator_round_trips_asm(uint32_t* turn_ptr,
+                                                size_t round_trips,
+                                                uint32_t initiator_turn,
+                                                uint32_t responder_turn);
+
+    /**
+     * @brief Core-to-core responder ping-pong loop (assembly)
+     * @param turn_ptr Shared turn token pointer
+     * @param round_trips Number of round trips to execute
+     * @param responder_turn Token value owned by responder
+     * @param initiator_turn Token value owned by initiator
+     */
+    void core_to_core_responder_round_trips_asm(uint32_t* turn_ptr,
+                                                size_t round_trips,
+                                                uint32_t responder_turn,
+                                                uint32_t initiator_turn);
+     
     // Pattern-specific assembly functions
     // Reverse sequential
     /**

--- a/src/asm/core_to_core_latency.s
+++ b/src/asm/core_to_core_latency.s
@@ -1,0 +1,103 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// core_to_core_initiator_round_trips_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void core_to_core_initiator_round_trips_asm(
+//       uint32_t* turn_ptr,
+//       size_t round_trips,
+//       uint32_t initiator_turn,
+//       uint32_t responder_turn);
+// Purpose:
+//   Execute initiator side of a cache-line handoff ping-pong loop.
+//   Each round trip waits for initiator ownership, hands token to responder,
+//   then waits for token return.
+// Arguments:
+//   x0 = turn_ptr
+//   x1 = round_trips
+//   w2 = initiator_turn
+//   w3 = responder_turn
+// Returns:
+//   (none)
+// Clobbers:
+//   w8
+// -----------------------------------------------------------------------------
+
+.global _core_to_core_initiator_round_trips_asm
+.align 4
+_core_to_core_initiator_round_trips_asm:
+    cbz x1, c2c_initiator_end
+
+c2c_initiator_loop:
+c2c_initiator_wait_turn:
+    ldar w8, [x0]                    // Acquire current token
+    cmp w8, w2                       // Wait until initiator owns token
+    b.ne c2c_initiator_wait_turn
+
+    stlr w3, [x0]                    // Release token to responder
+
+c2c_initiator_wait_return:
+    ldar w8, [x0]                    // Acquire current token
+    cmp w8, w2                       // Wait until responder returns token
+    b.ne c2c_initiator_wait_return
+
+    subs x1, x1, #1
+    b.ne c2c_initiator_loop
+
+c2c_initiator_end:
+    ret
+
+// -----------------------------------------------------------------------------
+// core_to_core_responder_round_trips_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void core_to_core_responder_round_trips_asm(
+//       uint32_t* turn_ptr,
+//       size_t round_trips,
+//       uint32_t responder_turn,
+//       uint32_t initiator_turn);
+// Purpose:
+//   Execute responder side of a cache-line handoff ping-pong loop.
+//   Each round trip waits for responder ownership and hands token back.
+// Arguments:
+//   x0 = turn_ptr
+//   x1 = round_trips
+//   w2 = responder_turn
+//   w3 = initiator_turn
+// Returns:
+//   (none)
+// Clobbers:
+//   w8
+// -----------------------------------------------------------------------------
+
+.global _core_to_core_responder_round_trips_asm
+.align 4
+_core_to_core_responder_round_trips_asm:
+    cbz x1, c2c_responder_end
+
+c2c_responder_loop:
+c2c_responder_wait_turn:
+    ldar w8, [x0]                    // Acquire current token
+    cmp w8, w2                       // Wait until responder owns token
+    b.ne c2c_responder_wait_turn
+
+    stlr w3, [x0]                    // Release token to initiator
+
+    subs x1, x1, #1
+    b.ne c2c_responder_loop
+
+c2c_responder_end:
+    ret

--- a/src/benchmark/core_to_core_latency.h
+++ b/src/benchmark/core_to_core_latency.h
@@ -1,0 +1,80 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file core_to_core_latency.h
+ * @brief Standalone core-to-core cache-line handoff benchmark mode interfaces
+ * @author Timo Heimonen <timo.heimonen@proton.me>
+ * @date 2026
+ */
+
+#ifndef CORE_TO_CORE_LATENCY_H
+#define CORE_TO_CORE_LATENCY_H
+
+#include <string>
+#include <vector>
+
+#include "core/config/constants.h"
+
+struct CoreToCoreLatencyConfig {
+  int loop_count = Constants::CORE_TO_CORE_DEFAULT_LOOP_COUNT;
+  int latency_sample_count = Constants::CORE_TO_CORE_DEFAULT_LATENCY_SAMPLE_COUNT;
+  std::string output_file;
+  bool help_requested = false;
+};
+
+struct ThreadHintStatus {
+  bool qos_applied = false;
+  int qos_code = 0;
+  bool affinity_requested = false;
+  bool affinity_applied = false;
+  int affinity_code = 0;
+  int affinity_tag = 0;
+};
+
+struct CoreToCoreLatencyScenarioResult {
+  std::string scenario_name;
+  std::vector<double> loop_round_trip_ns;
+  std::vector<double> sample_round_trip_ns;
+  ThreadHintStatus initiator_hint;
+  ThreadHintStatus responder_hint;
+};
+
+/**
+ * @brief Parse CLI args for standalone core-to-core mode.
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @param config Output mode configuration.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on parse/validation error.
+ */
+int parse_core_to_core_mode_arguments(int argc, char* argv[], CoreToCoreLatencyConfig& config);
+
+/**
+ * @brief Run standalone core-to-core cache-line handoff benchmark.
+ * @param config Parsed mode configuration.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on runtime/IO error.
+ */
+int run_core_to_core_latency(const CoreToCoreLatencyConfig& config);
+
+/**
+ * @brief Parse and run standalone core-to-core mode from main().
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on error.
+ */
+int run_core_to_core_latency_mode(int argc, char* argv[]);
+
+#endif  // CORE_TO_CORE_LATENCY_H

--- a/src/benchmark/core_to_core_latency_cli.cpp
+++ b/src/benchmark/core_to_core_latency_cli.cpp
@@ -1,0 +1,209 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file core_to_core_latency_cli.cpp
+ * @brief CLI parsing for standalone core-to-core latency mode
+ * @author Timo Heimonen <timo.heimonen@proton.me>
+ * @date 2026
+ *
+ * Parses and validates mode-specific command line options for `-analyze-core2core`.
+ * This parser intentionally accepts only a small, explicit option set so the
+ * standalone mode remains isolated from standard benchmark orchestration flags.
+ */
+
+#include "benchmark/core_to_core_latency.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#include "core/config/constants.h"
+#include "output/console/messages.h"
+#include "output/console/output_printer.h"
+
+namespace {
+
+// Shared validator for positive integer options used by standalone mode flags.
+bool parse_positive_int_option(const std::string& option,
+                               const std::string& value,
+                               int& out_value,
+                               const char* prog_name) {
+  long long parsed = 0;
+  try {
+    parsed = std::stoll(value);
+  } catch (const std::invalid_argument&) {
+    std::cerr << Messages::error_prefix()
+              << Messages::error_invalid_value(option, value, "must be an integer")
+              << std::endl;
+    print_usage(prog_name);
+    return false;
+  } catch (const std::out_of_range&) {
+    std::cerr << Messages::error_prefix()
+              << Messages::error_invalid_value(option, value, "out of range")
+              << std::endl;
+    print_usage(prog_name);
+    return false;
+  }
+
+  if (parsed <= 0 || parsed > std::numeric_limits<int>::max()) {
+    std::cerr << Messages::error_prefix()
+              << Messages::error_invalid_value(
+                     option,
+                     value,
+                     "must be between 1 and " + std::to_string(std::numeric_limits<int>::max()))
+              << std::endl;
+    print_usage(prog_name);
+    return false;
+  }
+
+  out_value = static_cast<int>(parsed);
+  return true;
+}
+
+}  // namespace
+
+int parse_core_to_core_mode_arguments(int argc, char* argv[], CoreToCoreLatencyConfig& config) {
+  // Always start from centralized core-to-core defaults.
+  config.loop_count = Constants::CORE_TO_CORE_DEFAULT_LOOP_COUNT;
+  config.latency_sample_count = Constants::CORE_TO_CORE_DEFAULT_LATENCY_SAMPLE_COUNT;
+
+  bool mode_seen = false;
+  bool output_seen = false;
+  bool count_seen = false;
+  bool samples_seen = false;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+
+    // Mode flag is required but does not consume a value.
+    if (arg == "-analyze-core2core") {
+      mode_seen = true;
+      continue;
+    }
+
+    // Help is an early-exit path for this standalone parser.
+    if (arg == "-h" || arg == "--help") {
+      print_usage(argv[0]);
+      config.help_requested = true;
+      return EXIT_SUCCESS;
+    }
+
+    // Optional JSON output target.
+    if (arg == "-output") {
+      if (output_seen) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_duplicate_option("-output")
+                  << std::endl;
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+      }
+      if (++i >= argc) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_missing_value("-output")
+                  << std::endl;
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+      }
+      config.output_file = argv[i];
+      output_seen = true;
+      continue;
+    }
+
+    // Optional benchmark loop count override.
+    if (arg == "-count") {
+      if (count_seen) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_duplicate_option("-count")
+                  << std::endl;
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+      }
+      if (++i >= argc) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_missing_value("-count")
+                  << std::endl;
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+      }
+      if (!parse_positive_int_option("-count", argv[i], config.loop_count, argv[0])) {
+        return EXIT_FAILURE;
+      }
+      count_seen = true;
+      continue;
+    }
+
+    // Optional per-loop latency sample count override.
+    if (arg == "-latency-samples") {
+      if (samples_seen) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_duplicate_option("-latency-samples")
+                  << std::endl;
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+      }
+      if (++i >= argc) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_missing_value("-latency-samples")
+                  << std::endl;
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+      }
+      if (!parse_positive_int_option("-latency-samples",
+                                     argv[i],
+                                     config.latency_sample_count,
+                                     argv[0])) {
+        return EXIT_FAILURE;
+      }
+      samples_seen = true;
+      continue;
+    }
+
+    // Any unknown or standard-mode option is rejected in standalone mode.
+    std::cerr << Messages::error_prefix()
+              << Messages::error_analyze_core_to_core_must_be_used_alone()
+              << std::endl;
+    print_usage(argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  if (!mode_seen) {
+    std::cerr << Messages::error_prefix()
+              << Messages::error_analyze_core_to_core_must_be_used_alone()
+              << std::endl;
+    print_usage(argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
+int run_core_to_core_latency_mode(int argc, char* argv[]) {
+  CoreToCoreLatencyConfig config;
+  const int parse_result = parse_core_to_core_mode_arguments(argc, argv, config);
+  if (parse_result != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+
+  if (config.help_requested) {
+    return EXIT_SUCCESS;
+  }
+
+  // Execute benchmark only after successful parse and non-help path.
+  return run_core_to_core_latency(config);
+}

--- a/src/benchmark/core_to_core_latency_json.cpp
+++ b/src/benchmark/core_to_core_latency_json.cpp
@@ -1,0 +1,141 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file core_to_core_latency_json.cpp
+ * @brief JSON serialization for standalone core-to-core latency mode
+ * @author Timo Heimonen <timo.heimonen@proton.me>
+ * @date 2026
+ *
+ * Builds mode-specific JSON output for cache-line handoff measurements,
+ * scenario metadata, and scheduler-hint status used during each scenario run.
+ */
+
+#include "benchmark/core_to_core_latency_json.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "core/config/version.h"
+#include "output/json/json_output.h"
+#include "utils/json_utils.h"
+
+namespace {
+
+nlohmann::ordered_json build_thread_hint_json(const ThreadHintStatus& hint_status) {
+  nlohmann::ordered_json hint_json;
+  hint_json["qos_applied"] = hint_status.qos_applied;
+  hint_json["qos_code"] = hint_status.qos_code;
+  hint_json["affinity_requested"] = hint_status.affinity_requested;
+  hint_json["affinity_applied"] = hint_status.affinity_applied;
+  hint_json["affinity_code"] = hint_status.affinity_code;
+  hint_json["affinity_tag"] = hint_status.affinity_tag;
+  return hint_json;
+}
+
+std::string build_utc_timestamp() {
+  const auto now = std::chrono::system_clock::now();
+  const auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  std::tm utc_time;
+  gmtime_r(&time_t_now, &utc_time);
+
+  std::ostringstream timestamp_str;
+  timestamp_str << std::put_time(&utc_time, "%Y-%m-%dT%H:%M:%SZ");
+  return timestamp_str.str();
+}
+
+nlohmann::ordered_json build_scenario_json(const CoreToCoreLatencyScenarioResult& scenario_result) {
+  nlohmann::ordered_json scenario_json;
+  scenario_json["name"] = scenario_result.scenario_name;
+
+  scenario_json["round_trip_ns"][JsonKeys::VALUES] = scenario_result.loop_round_trip_ns;
+  if (scenario_result.loop_round_trip_ns.size() > 1) {
+    scenario_json["round_trip_ns"][JsonKeys::STATISTICS] =
+        calculate_json_statistics(scenario_result.loop_round_trip_ns);
+  }
+
+  std::vector<double> one_way_estimate_ns;
+  one_way_estimate_ns.reserve(scenario_result.loop_round_trip_ns.size());
+  for (double round_trip_ns : scenario_result.loop_round_trip_ns) {
+    one_way_estimate_ns.push_back(round_trip_ns * 0.5);
+  }
+  scenario_json["one_way_estimate_ns"][JsonKeys::VALUES] = one_way_estimate_ns;
+  if (one_way_estimate_ns.size() > 1) {
+    scenario_json["one_way_estimate_ns"][JsonKeys::STATISTICS] =
+        calculate_json_statistics(one_way_estimate_ns);
+  }
+
+  scenario_json[JsonKeys::SAMPLES_NS][JsonKeys::VALUES] = scenario_result.sample_round_trip_ns;
+  if (scenario_result.sample_round_trip_ns.size() > 1) {
+    scenario_json[JsonKeys::SAMPLES_NS][JsonKeys::STATISTICS] =
+        calculate_json_statistics(scenario_result.sample_round_trip_ns);
+  }
+
+  scenario_json["thread_hints"] = {
+      {"initiator", build_thread_hint_json(scenario_result.initiator_hint)},
+      {"responder", build_thread_hint_json(scenario_result.responder_hint)},
+  };
+
+  return scenario_json;
+}
+
+}  // namespace
+
+int save_core_to_core_latency_to_json(const CoreToCoreLatencyJsonContext& context) {
+  if (context.config.output_file.empty()) {
+    return EXIT_SUCCESS;
+  }
+
+  nlohmann::ordered_json json_output;
+  json_output[JsonKeys::CONFIGURATION] = {
+      {"mode", Constants::CORE_TO_CORE_JSON_MODE_NAME},
+      {JsonKeys::CPU_NAME, context.cpu_name},
+      {JsonKeys::PERFORMANCE_CORES, context.perf_cores},
+      {JsonKeys::EFFICIENCY_CORES, context.eff_cores},
+      {JsonKeys::LOOP_COUNT, context.config.loop_count},
+      {JsonKeys::LATENCY_SAMPLE_COUNT, context.config.latency_sample_count},
+      {"warmup_round_trips", context.warmup_round_trips},
+      {"headline_round_trips", context.headline_round_trips},
+      {"sample_window_round_trips", context.sample_window_round_trips},
+  };
+  json_output[JsonKeys::EXECUTION_TIME_SEC] = context.total_execution_time_sec;
+
+  nlohmann::ordered_json scenario_array = nlohmann::ordered_json::array();
+  for (const CoreToCoreLatencyScenarioResult& scenario_result : context.scenario_results) {
+    scenario_array.push_back(build_scenario_json(scenario_result));
+  }
+
+  json_output["core_to_core_latency"] = {
+      {"scenarios", scenario_array},
+      {"hard_pinning_supported", Constants::CORE_TO_CORE_JSON_HARD_PINNING_SUPPORTED},
+      {"affinity_tags_are_hints", Constants::CORE_TO_CORE_JSON_AFFINITY_TAGS_ARE_HINTS},
+  };
+
+  json_output[JsonKeys::TIMESTAMP] = build_utc_timestamp();
+  json_output[JsonKeys::VERSION] = SOFTVERSION;
+
+  std::filesystem::path file_path(context.config.output_file);
+  if (file_path.is_relative()) {
+    file_path = std::filesystem::current_path() / file_path;
+  }
+
+  return write_json_to_file(file_path, json_output);
+}

--- a/src/benchmark/core_to_core_latency_json.h
+++ b/src/benchmark/core_to_core_latency_json.h
@@ -1,0 +1,47 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file core_to_core_latency_json.h
+ * @brief JSON serialization helpers for standalone core-to-core latency mode
+ * @author Timo Heimonen <timo.heimonen@proton.me>
+ * @date 2026
+ */
+
+#ifndef CORE_TO_CORE_LATENCY_JSON_H
+#define CORE_TO_CORE_LATENCY_JSON_H
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "benchmark/core_to_core_latency.h"
+
+struct CoreToCoreLatencyJsonContext {
+  const CoreToCoreLatencyConfig& config;
+  const std::string& cpu_name;
+  int perf_cores;
+  int eff_cores;
+  size_t warmup_round_trips;
+  size_t headline_round_trips;
+  size_t sample_window_round_trips;
+  const std::vector<CoreToCoreLatencyScenarioResult>& scenario_results;
+  double total_execution_time_sec;
+};
+
+int save_core_to_core_latency_to_json(const CoreToCoreLatencyJsonContext& context);
+
+#endif  // CORE_TO_CORE_LATENCY_JSON_H

--- a/src/benchmark/core_to_core_latency_runner.cpp
+++ b/src/benchmark/core_to_core_latency_runner.cpp
@@ -1,0 +1,399 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file core_to_core_latency_runner.cpp
+ * @brief Standalone core-to-core cache-line handoff benchmark implementation (@author Timo Heimonen <timo.heimonen@proton.me>, @date 2026)
+ */
+
+#include "benchmark/core_to_core_latency.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <mach/mach.h>
+#include <mach/thread_policy.h>
+#include <pthread.h>
+#include <pthread/qos.h>
+
+#include "benchmark/core_to_core_latency_json.h"
+#include "core/config/constants.h"
+#include "core/config/version.h"
+#include "core/system/system_info.h"
+#include "core/timing/timer.h"
+#include "output/console/messages.h"
+
+namespace {
+
+struct SummaryStats {
+  double average = 0.0;
+  double min = 0.0;
+  double max = 0.0;
+  double median = 0.0;
+  double p90 = 0.0;
+  double p95 = 0.0;
+  double p99 = 0.0;
+  double stddev = 0.0;
+};
+
+struct ScenarioDescriptor {
+  std::string name;
+  bool apply_affinity = false;
+  int initiator_affinity_tag = 0;
+  int responder_affinity_tag = 0;
+};
+
+struct ScenarioMeasurement {
+  double round_trip_ns = 0.0;
+  std::vector<double> samples_ns;
+  ThreadHintStatus initiator_hint;
+  ThreadHintStatus responder_hint;
+};
+
+struct alignas(Constants::CACHE_LINE_SIZE_BYTES) SharedTurn {
+  std::atomic<uint32_t> value{Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE};
+};
+
+struct alignas(Constants::CACHE_LINE_SIZE_BYTES) SharedFlags {
+  std::atomic<bool> start{false};
+  std::atomic<bool> stop{false};
+  std::atomic<int> ready_threads{0};
+};
+
+struct SharedPingPongState {
+  SharedTurn turn;
+  SharedFlags flags;
+};
+double calculate_average(const std::vector<double>& values) {
+  if (values.empty()) {
+    return 0.0;
+  }
+
+  double sum = 0.0;
+  for (double v : values) {
+    sum += v;
+  }
+  return sum / static_cast<double>(values.size());
+}
+
+SummaryStats calculate_summary_stats(const std::vector<double>& values) {
+  SummaryStats stats;
+  if (values.empty()) {
+    return stats;
+  }
+
+  stats.average = calculate_average(values);
+  stats.min = *std::min_element(values.begin(), values.end());
+  stats.max = *std::max_element(values.begin(), values.end());
+
+  std::vector<double> sorted = values;
+  std::sort(sorted.begin(), sorted.end());
+  const size_t n = sorted.size();
+
+  const auto percentile = [&sorted, n](double p) {
+    if (n == 1) {
+      return sorted[0];
+    }
+    const double idx = p * static_cast<double>(n - 1);
+    const size_t lower = static_cast<size_t>(idx);
+    const size_t upper = lower + 1;
+    if (upper >= n) {
+      return sorted[n - 1];
+    }
+    const double weight = idx - static_cast<double>(lower);
+    return sorted[lower] * (1.0 - weight) + sorted[upper] * weight;
+  };
+
+  stats.median = percentile(0.50);
+  stats.p90 = percentile(0.90);
+  stats.p95 = percentile(0.95);
+  stats.p99 = percentile(0.99);
+
+  if (values.size() > 1) {
+    double variance_sum = 0.0;
+    for (double v : values) {
+      const double diff = v - stats.average;
+      variance_sum += diff * diff;
+    }
+    stats.stddev = std::sqrt(variance_sum / static_cast<double>(values.size() - 1));
+  }
+
+  return stats;
+}
+
+ThreadHintStatus apply_thread_hints(bool request_affinity, int affinity_tag) {
+  ThreadHintStatus status;
+
+  const int qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+  status.qos_applied = (qos_ret == KERN_SUCCESS);
+  status.qos_code = qos_ret;
+
+  status.affinity_requested = request_affinity;
+  status.affinity_tag = affinity_tag;
+  if (!request_affinity) {
+    return status;
+  }
+
+  thread_affinity_policy_data_t affinity_policy = {affinity_tag};
+  const thread_port_t mach_thread = pthread_mach_thread_np(pthread_self());
+  const kern_return_t affinity_ret =
+      thread_policy_set(mach_thread,
+                        THREAD_AFFINITY_POLICY,
+                        reinterpret_cast<thread_policy_t>(&affinity_policy),
+                        THREAD_AFFINITY_POLICY_COUNT);
+  status.affinity_applied = (affinity_ret == KERN_SUCCESS);
+  status.affinity_code = affinity_ret;
+  return status;
+}
+// Busy-wait start barrier keeps thread creation outside timed region.
+void wait_for_start_signal(const SharedPingPongState& state) {
+  while (!state.flags.start.load(std::memory_order_acquire)) {
+  }
+}
+// One round trip: initiator hands token to responder and waits to get it back.
+void run_round_trip_batch(SharedPingPongState& state, size_t round_trips) {
+  for (size_t i = 0; i < round_trips; ++i) {
+    while (state.turn.value.load(std::memory_order_acquire) != Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE) {
+    }
+    state.turn.value.store(Constants::CORE_TO_CORE_RESPONDER_TURN_VALUE, std::memory_order_release);
+    while (state.turn.value.load(std::memory_order_acquire) != Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE) {
+    }
+  }
+}
+// Responder spins for token ownership and returns it to initiator.
+void responder_loop(SharedPingPongState& state) {
+  while (true) {
+    while (state.turn.value.load(std::memory_order_acquire) != Constants::CORE_TO_CORE_RESPONDER_TURN_VALUE) {
+      if (state.flags.stop.load(std::memory_order_acquire)) {
+        return;
+      }
+    }
+    state.turn.value.store(Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE, std::memory_order_release);
+  }
+}
+bool execute_single_scenario(const ScenarioDescriptor& scenario,
+                             int sample_count,
+                             ScenarioMeasurement& out_measurement) {
+  SharedPingPongState state;
+  bool timer_creation_failed = false;
+
+  std::thread responder_thread([&state, &scenario, &out_measurement]() {
+    out_measurement.responder_hint =
+        apply_thread_hints(scenario.apply_affinity, scenario.responder_affinity_tag);
+    state.flags.ready_threads.fetch_add(1, std::memory_order_release);
+    wait_for_start_signal(state);
+    responder_loop(state);
+  });
+
+  std::thread initiator_thread([&state, &scenario, &out_measurement, sample_count, &timer_creation_failed]() {
+    out_measurement.initiator_hint =
+        apply_thread_hints(scenario.apply_affinity, scenario.initiator_affinity_tag);
+    state.flags.ready_threads.fetch_add(1, std::memory_order_release);
+    wait_for_start_signal(state);
+
+    run_round_trip_batch(state, Constants::CORE_TO_CORE_WARMUP_ROUND_TRIPS);
+
+    auto timer_opt = HighResTimer::create();
+    if (!timer_opt) {
+      timer_creation_failed = true;
+      state.flags.stop.store(true, std::memory_order_release);
+      return;
+    }
+
+    auto& timer = *timer_opt;
+    timer.start();
+    run_round_trip_batch(state, Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS);
+    const double headline_total_ns = timer.stop_ns();
+    out_measurement.round_trip_ns = headline_total_ns / static_cast<double>(Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS);
+
+    out_measurement.samples_ns.reserve(static_cast<size_t>(sample_count));
+    for (int sample_index = 0; sample_index < sample_count; ++sample_index) {
+      timer.start();
+      run_round_trip_batch(state, Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS);
+      const double sample_total_ns = timer.stop_ns();
+      out_measurement.samples_ns.push_back(sample_total_ns /
+                                           static_cast<double>(Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS));
+    }
+
+    state.flags.stop.store(true, std::memory_order_release);
+  });
+
+  // Ensure both worker threads have applied hints before starting handoff loop.
+  while (state.flags.ready_threads.load(std::memory_order_acquire) < Constants::CORE_TO_CORE_READY_THREADS_TARGET) {
+  }
+  state.turn.value.store(Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE, std::memory_order_release);
+  state.flags.start.store(true, std::memory_order_release);
+
+  initiator_thread.join();
+  responder_thread.join();
+
+  return !timer_creation_failed;
+}
+// Scenarios are interpreted as scheduler-hint requests, not hard pinning contracts.
+std::vector<ScenarioDescriptor> build_scenarios() {
+  std::vector<ScenarioDescriptor> scenarios;
+  scenarios.push_back({Constants::CORE_TO_CORE_SCENARIO_NO_AFFINITY,
+                       Constants::CORE_TO_CORE_AFFINITY_HINT_DISABLED,
+                       Constants::CORE_TO_CORE_AFFINITY_TAG_NONE,
+                       Constants::CORE_TO_CORE_AFFINITY_TAG_NONE});
+  scenarios.push_back({Constants::CORE_TO_CORE_SCENARIO_SAME_AFFINITY,
+                       Constants::CORE_TO_CORE_AFFINITY_HINT_ENABLED,
+                       Constants::CORE_TO_CORE_AFFINITY_TAG_PRIMARY,
+                       Constants::CORE_TO_CORE_AFFINITY_TAG_PRIMARY});
+  scenarios.push_back({Constants::CORE_TO_CORE_SCENARIO_DIFFERENT_AFFINITY,
+                       Constants::CORE_TO_CORE_AFFINITY_HINT_ENABLED,
+                       Constants::CORE_TO_CORE_AFFINITY_TAG_PRIMARY,
+                       Constants::CORE_TO_CORE_AFFINITY_TAG_SECONDARY});
+  return scenarios;
+}
+
+void print_scenario_report(const CoreToCoreLatencyScenarioResult& scenario_result) {
+  const double avg_round_trip_ns = calculate_average(scenario_result.loop_round_trip_ns);
+  const double one_way_estimate_ns = avg_round_trip_ns * 0.5;
+  const SummaryStats sample_stats = calculate_summary_stats(scenario_result.sample_round_trip_ns);
+
+  std::cout << std::endl;
+  std::cout << Messages::report_core_to_core_scenario_title(scenario_result.scenario_name) << std::endl;
+  std::cout << Messages::report_core_to_core_round_trip(avg_round_trip_ns) << std::endl;
+  std::cout << Messages::report_core_to_core_one_way_estimate(one_way_estimate_ns) << std::endl;
+  std::cout << Messages::report_core_to_core_samples(scenario_result.sample_round_trip_ns.size())
+            << std::endl;
+  std::cout << "    "
+            << Messages::statistics_median_p50(sample_stats.median, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << "    " << Messages::statistics_p90(sample_stats.p90, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << "    " << Messages::statistics_p95(sample_stats.p95, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << "    " << Messages::statistics_p99(sample_stats.p99, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << "    "
+            << Messages::statistics_stddev(sample_stats.stddev, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << "    " << Messages::statistics_min(sample_stats.min, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << "    " << Messages::statistics_max(sample_stats.max, Constants::LATENCY_PRECISION)
+            << std::endl;
+  std::cout << Messages::report_core_to_core_hint_status("Initiator",
+                                                         scenario_result.initiator_hint.qos_applied,
+                                                         scenario_result.initiator_hint.qos_code,
+                                                         scenario_result.initiator_hint.affinity_requested,
+                                                         scenario_result.initiator_hint.affinity_applied,
+                                                         scenario_result.initiator_hint.affinity_code,
+                                                         scenario_result.initiator_hint.affinity_tag)
+            << std::endl;
+  std::cout << Messages::report_core_to_core_hint_status("Responder",
+                                                         scenario_result.responder_hint.qos_applied,
+                                                         scenario_result.responder_hint.qos_code,
+                                                         scenario_result.responder_hint.affinity_requested,
+                                                         scenario_result.responder_hint.affinity_applied,
+                                                         scenario_result.responder_hint.affinity_code,
+                                                         scenario_result.responder_hint.affinity_tag)
+            << std::endl;
+}
+
+}  // namespace
+
+int run_core_to_core_latency(const CoreToCoreLatencyConfig& config) {
+  const auto analysis_start = std::chrono::steady_clock::now();
+
+  std::cout << Messages::usage_header(SOFTVERSION);
+  std::cout << Messages::msg_running_core_to_core_analysis() << std::endl;
+
+  const std::string cpu_name = get_processor_name();
+  const int perf_cores = get_performance_cores();
+  const int eff_cores = get_efficiency_cores();
+
+  const std::vector<ScenarioDescriptor> scenarios = build_scenarios();
+  std::vector<CoreToCoreLatencyScenarioResult> scenario_results;
+  scenario_results.reserve(scenarios.size());
+  for (const ScenarioDescriptor& scenario : scenarios) {
+    CoreToCoreLatencyScenarioResult result;
+    result.scenario_name = scenario.name;
+    scenario_results.push_back(std::move(result));
+  }
+
+  for (int loop_index = 0; loop_index < config.loop_count; ++loop_index) {
+    for (size_t scenario_index = 0; scenario_index < scenarios.size(); ++scenario_index) {
+      const ScenarioDescriptor& scenario = scenarios[scenario_index];
+      std::cout << Messages::msg_core_to_core_scenario_progress(
+                       static_cast<size_t>(loop_index + 1),
+                       static_cast<size_t>(config.loop_count),
+                       scenario.name)
+                << std::endl;
+
+      ScenarioMeasurement measurement;
+      if (!execute_single_scenario(scenario, config.latency_sample_count, measurement)) {
+        std::cerr << Messages::error_prefix()
+                  << Messages::error_core_to_core_timer_creation_failed()
+                  << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      CoreToCoreLatencyScenarioResult& scenario_result = scenario_results[scenario_index];
+      scenario_result.loop_round_trip_ns.push_back(measurement.round_trip_ns);
+      scenario_result.sample_round_trip_ns.insert(scenario_result.sample_round_trip_ns.end(),
+                                                  measurement.samples_ns.begin(),
+                                                  measurement.samples_ns.end());
+      if (loop_index == 0) {
+        scenario_result.initiator_hint = measurement.initiator_hint;
+        scenario_result.responder_hint = measurement.responder_hint;
+      }
+    }
+  }
+
+  std::cout << std::endl;
+  std::cout << Messages::report_core_to_core_header() << std::endl;
+  std::cout << Messages::report_core_to_core_scheduler_note() << std::endl;
+  std::cout << Messages::report_core_to_core_cpu(cpu_name) << std::endl;
+  std::cout << Messages::report_core_to_core_cores(perf_cores, eff_cores) << std::endl;
+  std::cout << Messages::report_core_to_core_loop_config(config.loop_count,
+                                                         config.latency_sample_count,
+                                                         Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS,
+                                                         Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS)
+            << std::endl;
+
+  for (const CoreToCoreLatencyScenarioResult& scenario_result : scenario_results) {
+    print_scenario_report(scenario_result);
+  }
+
+  const auto analysis_end = std::chrono::steady_clock::now();
+  const double total_execution_time_sec =
+      std::chrono::duration<double>(analysis_end - analysis_start).count();
+
+  const CoreToCoreLatencyJsonContext json_context = {
+      config,
+      cpu_name,
+      perf_cores,
+      eff_cores,
+      Constants::CORE_TO_CORE_WARMUP_ROUND_TRIPS,
+      Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS,
+      Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS,
+      scenario_results,
+      total_execution_time_sec,
+  };
+  if (save_core_to_core_latency_to_json(json_context) != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/benchmark/core_to_core_latency_runner.cpp
+++ b/src/benchmark/core_to_core_latency_runner.cpp
@@ -35,6 +35,7 @@
 #include <pthread.h>
 #include <pthread/qos.h>
 
+#include "asm/asm_functions.h"
 #include "benchmark/core_to_core_latency_json.h"
 #include "core/config/constants.h"
 #include "core/config/version.h"
@@ -70,12 +71,11 @@ struct ScenarioMeasurement {
 };
 
 struct alignas(Constants::CACHE_LINE_SIZE_BYTES) SharedTurn {
-  std::atomic<uint32_t> value{Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE};
+  uint32_t value = Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE;
 };
 
 struct alignas(Constants::CACHE_LINE_SIZE_BYTES) SharedFlags {
   std::atomic<bool> start{false};
-  std::atomic<bool> stop{false};
   std::atomic<int> ready_threads{0};
 };
 
@@ -83,6 +83,7 @@ struct SharedPingPongState {
   SharedTurn turn;
   SharedFlags flags;
 };
+
 double calculate_average(const std::vector<double>& values) {
   if (values.empty()) {
     return 0.0;
@@ -164,89 +165,88 @@ ThreadHintStatus apply_thread_hints(bool request_affinity, int affinity_tag) {
   status.affinity_code = affinity_ret;
   return status;
 }
+
 // Busy-wait start barrier keeps thread creation outside timed region.
 void wait_for_start_signal(const SharedPingPongState& state) {
   while (!state.flags.start.load(std::memory_order_acquire)) {
   }
 }
+
+size_t calculate_total_responder_round_trips(int sample_count) {
+  return Constants::CORE_TO_CORE_WARMUP_ROUND_TRIPS +
+         Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS +
+         (static_cast<size_t>(sample_count) * Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS);
+}
+
 // One round trip: initiator hands token to responder and waits to get it back.
-void run_round_trip_batch(SharedPingPongState& state, size_t round_trips) {
-  for (size_t i = 0; i < round_trips; ++i) {
-    while (state.turn.value.load(std::memory_order_acquire) != Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE) {
-    }
-    state.turn.value.store(Constants::CORE_TO_CORE_RESPONDER_TURN_VALUE, std::memory_order_release);
-    while (state.turn.value.load(std::memory_order_acquire) != Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE) {
-    }
-  }
+void run_round_trip_batch(uint32_t* turn_ptr, size_t round_trips) {
+  core_to_core_initiator_round_trips_asm(turn_ptr,
+                                         round_trips,
+                                         Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE,
+                                         Constants::CORE_TO_CORE_RESPONDER_TURN_VALUE);
 }
-// Responder spins for token ownership and returns it to initiator.
-void responder_loop(SharedPingPongState& state) {
-  while (true) {
-    while (state.turn.value.load(std::memory_order_acquire) != Constants::CORE_TO_CORE_RESPONDER_TURN_VALUE) {
-      if (state.flags.stop.load(std::memory_order_acquire)) {
-        return;
-      }
-    }
-    state.turn.value.store(Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE, std::memory_order_release);
-  }
+
+void run_responder_round_trip_batch(uint32_t* turn_ptr, size_t round_trips) {
+  core_to_core_responder_round_trips_asm(turn_ptr,
+                                         round_trips,
+                                         Constants::CORE_TO_CORE_RESPONDER_TURN_VALUE,
+                                         Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE);
 }
+
 bool execute_single_scenario(const ScenarioDescriptor& scenario,
                              int sample_count,
                              ScenarioMeasurement& out_measurement) {
-  SharedPingPongState state;
-  bool timer_creation_failed = false;
+  auto timer_opt = HighResTimer::create();
+  if (!timer_opt) {
+    return false;
+  }
 
-  std::thread responder_thread([&state, &scenario, &out_measurement]() {
+  const size_t responder_round_trips = calculate_total_responder_round_trips(sample_count);
+
+  SharedPingPongState state;
+
+  std::thread responder_thread([&state, &scenario, &out_measurement, responder_round_trips]() {
     out_measurement.responder_hint =
         apply_thread_hints(scenario.apply_affinity, scenario.responder_affinity_tag);
     state.flags.ready_threads.fetch_add(1, std::memory_order_release);
     wait_for_start_signal(state);
-    responder_loop(state);
+    run_responder_round_trip_batch(&state.turn.value, responder_round_trips);
   });
 
-  std::thread initiator_thread([&state, &scenario, &out_measurement, sample_count, &timer_creation_failed]() {
+  std::thread initiator_thread([&state, &scenario, &out_measurement, sample_count, &timer_opt]() {
     out_measurement.initiator_hint =
         apply_thread_hints(scenario.apply_affinity, scenario.initiator_affinity_tag);
     state.flags.ready_threads.fetch_add(1, std::memory_order_release);
     wait_for_start_signal(state);
 
-    run_round_trip_batch(state, Constants::CORE_TO_CORE_WARMUP_ROUND_TRIPS);
-
-    auto timer_opt = HighResTimer::create();
-    if (!timer_opt) {
-      timer_creation_failed = true;
-      state.flags.stop.store(true, std::memory_order_release);
-      return;
-    }
+    run_round_trip_batch(&state.turn.value, Constants::CORE_TO_CORE_WARMUP_ROUND_TRIPS);
 
     auto& timer = *timer_opt;
     timer.start();
-    run_round_trip_batch(state, Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS);
+    run_round_trip_batch(&state.turn.value, Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS);
     const double headline_total_ns = timer.stop_ns();
     out_measurement.round_trip_ns = headline_total_ns / static_cast<double>(Constants::CORE_TO_CORE_HEADLINE_ROUND_TRIPS);
 
     out_measurement.samples_ns.reserve(static_cast<size_t>(sample_count));
     for (int sample_index = 0; sample_index < sample_count; ++sample_index) {
       timer.start();
-      run_round_trip_batch(state, Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS);
+      run_round_trip_batch(&state.turn.value, Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS);
       const double sample_total_ns = timer.stop_ns();
       out_measurement.samples_ns.push_back(sample_total_ns /
                                            static_cast<double>(Constants::CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS));
     }
-
-    state.flags.stop.store(true, std::memory_order_release);
   });
 
   // Ensure both worker threads have applied hints before starting handoff loop.
   while (state.flags.ready_threads.load(std::memory_order_acquire) < Constants::CORE_TO_CORE_READY_THREADS_TARGET) {
   }
-  state.turn.value.store(Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE, std::memory_order_release);
+  state.turn.value = Constants::CORE_TO_CORE_INITIATOR_TURN_VALUE;
   state.flags.start.store(true, std::memory_order_release);
 
   initiator_thread.join();
   responder_thread.join();
 
-  return !timer_creation_failed;
+  return true;
 }
 // Scenarios are interpreted as scheduler-hint requests, not hard pinning contracts.
 std::vector<ScenarioDescriptor> build_scenarios() {

--- a/src/core/config/constants.h
+++ b/src/core/config/constants.h
@@ -44,6 +44,7 @@
 #define CONSTANTS_H
 
 #include <cstddef>  // size_t
+#include <cstdint>  // uint32_t
 
 /**
  * @namespace Constants
@@ -99,6 +100,27 @@ namespace Constants {
   constexpr int DEFAULT_ITERATIONS = 1000;  // Default number of iterations for R/W/Copy tests
   constexpr int DEFAULT_LOOP_COUNT = 1;     // Default number of full benchmark loops
   constexpr int DEFAULT_LATENCY_SAMPLE_COUNT = 1000;  // Default number of latency samples per test
+
+  // Core-to-core standalone mode constants
+  constexpr int CORE_TO_CORE_DEFAULT_LOOP_COUNT = DEFAULT_LOOP_COUNT;  // Default loop count for standalone core-to-core mode
+  constexpr int CORE_TO_CORE_DEFAULT_LATENCY_SAMPLE_COUNT = DEFAULT_LATENCY_SAMPLE_COUNT;  // Default sample count per loop for core-to-core mode
+  constexpr size_t CORE_TO_CORE_WARMUP_ROUND_TRIPS = 20 * 1000;  // Warmup handoff count before timed measurements
+  constexpr size_t CORE_TO_CORE_HEADLINE_ROUND_TRIPS = 1 * 1000 * 1000;  // Round-trips used for headline latency metric
+  constexpr size_t CORE_TO_CORE_SAMPLE_WINDOW_ROUND_TRIPS = 2 * 1000;  // Round-trips per sampled measurement window
+  constexpr int CORE_TO_CORE_READY_THREADS_TARGET = 2;  // Required thread count before benchmark start signal
+  constexpr uint32_t CORE_TO_CORE_INITIATOR_TURN_VALUE = 0;  // Turn token value for initiator thread ownership
+  constexpr uint32_t CORE_TO_CORE_RESPONDER_TURN_VALUE = 1;  // Turn token value for responder thread ownership
+  constexpr int CORE_TO_CORE_AFFINITY_TAG_NONE = 0;  // No affinity tag requested for thread policy hint
+  constexpr int CORE_TO_CORE_AFFINITY_TAG_PRIMARY = 1;  // Primary affinity tag used in hinted scenarios
+  constexpr int CORE_TO_CORE_AFFINITY_TAG_SECONDARY = 2;  // Secondary affinity tag used for split-tag scenario
+  constexpr bool CORE_TO_CORE_AFFINITY_HINT_DISABLED = false;  // Scenario does not request affinity hint
+  constexpr bool CORE_TO_CORE_AFFINITY_HINT_ENABLED = true;  // Scenario requests affinity hint
+  constexpr const char CORE_TO_CORE_SCENARIO_NO_AFFINITY[] = "no_affinity_hint";  // Scenario name for no affinity policy hints
+  constexpr const char CORE_TO_CORE_SCENARIO_SAME_AFFINITY[] = "same_affinity_tag";  // Scenario name for matching affinity tags
+  constexpr const char CORE_TO_CORE_SCENARIO_DIFFERENT_AFFINITY[] = "different_affinity_tags";  // Scenario name for different affinity tags
+  constexpr const char CORE_TO_CORE_JSON_MODE_NAME[] = "analyze_core2core";  // Serialized mode identifier in JSON output
+  constexpr bool CORE_TO_CORE_JSON_HARD_PINNING_SUPPORTED = false;  // User-space hard core pinning is not available on macOS
+  constexpr bool CORE_TO_CORE_JSON_AFFINITY_TAGS_ARE_HINTS = true;  // Affinity tags are scheduler hints, not strict binding
   
   // Bandwidth calculation constants
   constexpr double NANOSECONDS_PER_SECOND = 1e9;  // Conversion factor for GB/s calculations

--- a/src/output/console/messages/core_to_core_messages.cpp
+++ b/src/output/console/messages/core_to_core_messages.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file core_to_core_messages.cpp
+ * @brief Message helpers for standalone core-to-core benchmark mode
+ * @author Timo Heimonen <timo.heimonen@proton.me>
+ * @date 2026
+ *
+ * Provides centralized user-facing strings for core-to-core mode so benchmark
+ * logic can format output without hardcoded text literals.
+ */
+
+#include "messages.h"
+
+#include <iomanip>
+#include <sstream>
+
+#include "core/config/constants.h"
+
+namespace Messages {
+
+const std::string& error_analyze_core_to_core_must_be_used_alone() {
+  static const std::string msg =
+      "-analyze-core2core allows only optional -output <file>, -count <count>, and "
+      "-latency-samples <count> (no other options allowed)";
+  return msg;
+}
+
+const std::string& error_core_to_core_timer_creation_failed() {
+  static const std::string msg = "Failed to create timer for core-to-core analysis";
+  return msg;
+}
+
+const std::string& msg_running_core_to_core_analysis() {
+  static const std::string msg = "\nRunning standalone core-to-core latency analysis...";
+  return msg;
+}
+
+std::string msg_core_to_core_scenario_progress(size_t current_loop,
+                                               size_t total_loops,
+                                               const std::string& scenario_name) {
+  std::ostringstream oss;
+  oss << "  [Loop " << current_loop << "/" << total_loops << "] Scenario: " << scenario_name;
+  return oss.str();
+}
+
+const std::string& report_core_to_core_header() {
+  static const std::string msg = "--- Core-to-Core Cache-Line Handoff Report ---";
+  return msg;
+}
+
+const std::string& report_core_to_core_scheduler_note() {
+  static const std::string msg =
+      "Scheduler note: macOS user-space cannot hard-pin threads to exact core IDs; "
+      "QoS/affinity are best-effort hints.";
+  return msg;
+}
+
+std::string report_core_to_core_cpu(const std::string& cpu_name) {
+  if (cpu_name.empty()) {
+    return "CPU: Unknown";
+  }
+  return "CPU: " + cpu_name;
+}
+
+std::string report_core_to_core_cores(int perf_cores, int eff_cores) {
+  std::ostringstream oss;
+  oss << "Detected Cores: " << perf_cores << " P, " << eff_cores << " E";
+  return oss.str();
+}
+
+std::string report_core_to_core_loop_config(int loop_count,
+                                            int sample_count,
+                                            size_t headline_round_trips,
+                                            size_t sample_window_round_trips) {
+  std::ostringstream oss;
+  oss << "Config: loops=" << loop_count << ", samples/loop=" << sample_count
+      << ", headline_round_trips=" << headline_round_trips
+      << ", sample_window_round_trips=" << sample_window_round_trips;
+  return oss.str();
+}
+
+std::string report_core_to_core_scenario_title(const std::string& scenario_name) {
+  return "[Scenario] " + scenario_name;
+}
+
+std::string report_core_to_core_round_trip(double round_trip_ns) {
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(Constants::LATENCY_PRECISION);
+  oss << "  Round-trip latency: " << round_trip_ns << " ns";
+  return oss.str();
+}
+
+std::string report_core_to_core_one_way_estimate(double one_way_ns) {
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(Constants::LATENCY_PRECISION);
+  oss << "  One-way estimate: " << one_way_ns << " ns";
+  return oss.str();
+}
+
+std::string report_core_to_core_samples(size_t sample_count) {
+  std::ostringstream oss;
+  oss << "  Samples: " << sample_count;
+  return oss.str();
+}
+
+std::string report_core_to_core_hint_status(const std::string& thread_role,
+                                            bool qos_applied,
+                                            int qos_code,
+                                            bool affinity_requested,
+                                            bool affinity_applied,
+                                            int affinity_code,
+                                            int affinity_tag) {
+  std::ostringstream oss;
+  oss << "  " << thread_role
+      << " hints: qos=" << (qos_applied ? "ok" : "failed(" + std::to_string(qos_code) + ")");
+  if (affinity_requested) {
+    oss << ", affinity(tag=" << affinity_tag << ")="
+        << (affinity_applied ? "ok" : "failed(" + std::to_string(affinity_code) + ")");
+  } else {
+    oss << ", affinity=not requested";
+  }
+  return oss.str();
+}
+
+}  // namespace Messages

--- a/src/output/console/messages/messages.h
+++ b/src/output/console/messages/messages.h
@@ -68,6 +68,8 @@ std::string error_latency_tlb_locality_page_multiple(size_t value_kb, size_t pag
 std::string error_latency_tlb_locality_too_small_for_stride(size_t locality_bytes, size_t stride_bytes);
 std::string error_threads_invalid(long long value, long long min_val, long long max_val);
 const std::string& error_analyze_tlb_must_be_used_alone();
+const std::string& error_analyze_core_to_core_must_be_used_alone();
+const std::string& error_core_to_core_timer_creation_failed();
 const std::string& error_tlb_analysis_insufficient_memory();
 const std::string& error_tlb_analysis_timer_creation_failed();
 std::string error_tlb_analysis_invalid_measurement(size_t locality_kb, int loop_number);
@@ -156,8 +158,33 @@ const std::string& msg_running_benchmarks();
 std::string msg_done_total_time(double total_time_sec);
 const std::string& msg_running_pattern_benchmarks();
 const std::string& msg_running_tlb_analysis();
+const std::string& msg_running_core_to_core_analysis();
+std::string msg_core_to_core_scenario_progress(size_t current_loop,
+                                               size_t total_loops,
+                                               const std::string& scenario_name);
 std::string msg_tlb_analysis_locality_progress(size_t current_index, size_t total_count, size_t locality_kb);
 std::string msg_tlb_analysis_page_walk_progress(size_t locality_mb);
+
+// --- Core-to-Core Report Messages ---
+const std::string& report_core_to_core_header();
+const std::string& report_core_to_core_scheduler_note();
+std::string report_core_to_core_cpu(const std::string& cpu_name);
+std::string report_core_to_core_cores(int perf_cores, int eff_cores);
+std::string report_core_to_core_loop_config(int loop_count,
+                                            int sample_count,
+                                            size_t headline_round_trips,
+                                            size_t sample_window_round_trips);
+std::string report_core_to_core_scenario_title(const std::string& scenario_name);
+std::string report_core_to_core_round_trip(double round_trip_ns);
+std::string report_core_to_core_one_way_estimate(double one_way_ns);
+std::string report_core_to_core_samples(size_t sample_count);
+std::string report_core_to_core_hint_status(const std::string& thread_role,
+                                            bool qos_applied,
+                                            int qos_code,
+                                            bool affinity_requested,
+                                            bool affinity_applied,
+                                            int affinity_code,
+                                            int affinity_tag);
 
 // --- TLB Analysis Report Messages ---
 const std::string& report_tlb_header();

--- a/src/output/console/messages/program_messages.cpp
+++ b/src/output/console/messages/program_messages.cpp
@@ -93,6 +93,8 @@ std::string usage_options(const std::string& prog_name) {
       << "  -count <count>        Number of full loops (read/write/copy/latency) (default: " << Constants::DEFAULT_LOOP_COUNT << ").\n"
       << "                        When count > 1, statistics include percentiles (P50/P90/P95/P99) and stddev.\n"
       << "  -analyze-tlb          Run standalone TLB analysis benchmark mode (allows optional -output <file> and -latency-stride-bytes <bytes> only).\n"
+      << "  -analyze-core2core    Run standalone core-to-core cache-line handoff benchmark mode\n"
+      << "                        (allows optional -output <file>, -count <count>, and -latency-samples <count> only).\n"
       << "  -latency-samples <count> Number of latency samples to collect per test (default: " << Constants::DEFAULT_LATENCY_SAMPLE_COUNT << ")\n"
       << "  -latency-stride-bytes <bytes> Stride used by latency pointer chains (default: "
       << Constants::LATENCY_STRIDE_BYTES << " bytes).\n"

--- a/tests/test_core_to_core_cli.cpp
+++ b/tests/test_core_to_core_cli.cpp
@@ -1,0 +1,108 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ * @file test_core_to_core_cli.cpp
+ * @brief Unit tests for standalone core-to-core CLI parsing
+ * @author Timo Heimonen <timo.heimonen@proton.me>
+ * @date 2026
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "benchmark/core_to_core_latency.h"
+#include "core/config/constants.h"
+
+namespace {
+
+// Builds argc/argv-style input and forwards to the standalone mode parser.
+int parse_with_args(const std::vector<std::string>& args, CoreToCoreLatencyConfig& config) {
+  std::vector<std::string> mutable_args = args;
+  std::vector<char*> argv;
+  argv.reserve(mutable_args.size());
+  for (std::string& arg : mutable_args) {
+    argv.push_back(const_cast<char*>(arg.c_str()));
+  }
+  return parse_core_to_core_mode_arguments(static_cast<int>(argv.size()), argv.data(), config);
+}
+
+}  // namespace
+
+TEST(CoreToCoreCliTest, ParsesDefaultStandaloneModeValues) {
+  // Baseline parse should inherit defaults directly from centralized constants.
+  CoreToCoreLatencyConfig config;
+  const int parse_result = parse_with_args({"memory_benchmark", "-analyze-core2core"}, config);
+
+  EXPECT_EQ(parse_result, EXIT_SUCCESS);
+  EXPECT_FALSE(config.help_requested);
+  EXPECT_EQ(config.loop_count, Constants::CORE_TO_CORE_DEFAULT_LOOP_COUNT);
+  EXPECT_EQ(config.latency_sample_count, Constants::CORE_TO_CORE_DEFAULT_LATENCY_SAMPLE_COUNT);
+  EXPECT_TRUE(config.output_file.empty());
+}
+
+TEST(CoreToCoreCliTest, ParsesOptionalModeArguments) {
+  // Optional standalone flags should override defaults without enabling help mode.
+  CoreToCoreLatencyConfig config;
+  const int parse_result =
+      parse_with_args({"memory_benchmark",
+                       "-analyze-core2core",
+                       "-count",
+                       "5",
+                       "-latency-samples",
+                       "128",
+                       "-output",
+                       "core2core.json"},
+                      config);
+
+  EXPECT_EQ(parse_result, EXIT_SUCCESS);
+  EXPECT_FALSE(config.help_requested);
+  EXPECT_EQ(config.loop_count, 5);
+  EXPECT_EQ(config.latency_sample_count, 128);
+  EXPECT_EQ(config.output_file, "core2core.json");
+}
+
+TEST(CoreToCoreCliTest, RejectsUnknownOptionsInStandaloneMode) {
+  // Standalone mode must reject standard benchmark options.
+  CoreToCoreLatencyConfig config;
+  const int parse_result = parse_with_args(
+      {"memory_benchmark", "-analyze-core2core", "-buffersize", "256"},
+      config);
+
+  EXPECT_EQ(parse_result, EXIT_FAILURE);
+}
+
+TEST(CoreToCoreCliTest, RejectsInvalidCountValues) {
+  // Count must be a positive integer.
+  CoreToCoreLatencyConfig config;
+  const int parse_result =
+      parse_with_args({"memory_benchmark", "-analyze-core2core", "-count", "0"}, config);
+
+  EXPECT_EQ(parse_result, EXIT_FAILURE);
+}
+
+TEST(CoreToCoreCliTest, HelpFlagReturnsSuccessAndSetsHelpRequested) {
+  // Help should short-circuit with success and mark help flag in config.
+  CoreToCoreLatencyConfig config;
+  const int parse_result = parse_with_args(
+      {"memory_benchmark", "-analyze-core2core", "-h"},
+      config);
+
+  EXPECT_EQ(parse_result, EXIT_SUCCESS);
+  EXPECT_TRUE(config.help_requested);
+}

--- a/tests/test_core_to_core_messages.cpp
+++ b/tests/test_core_to_core_messages.cpp
@@ -1,0 +1,50 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "output/console/messages.h"
+
+TEST(CoreToCoreMessagesTest, UsageMentionsStandaloneMode) {
+  const std::string usage = Messages::usage_options("memory_benchmark");
+  EXPECT_NE(usage.find("-analyze-core2core"), std::string::npos);
+}
+
+TEST(CoreToCoreMessagesTest, StandaloneModeErrorMessageExists) {
+  const std::string& msg = Messages::error_analyze_core_to_core_must_be_used_alone();
+  EXPECT_NE(msg.find("-analyze-core2core"), std::string::npos);
+  EXPECT_NE(msg.find("-output"), std::string::npos);
+  EXPECT_NE(msg.find("-count"), std::string::npos);
+  EXPECT_NE(msg.find("-latency-samples"), std::string::npos);
+}
+
+TEST(CoreToCoreMessagesTest, HintStatusMessageContainsRoleAndCodes) {
+  const std::string msg = Messages::report_core_to_core_hint_status(
+      "Initiator",
+      false,
+      100,
+      true,
+      false,
+      46,
+      1);
+
+  EXPECT_NE(msg.find("Initiator"), std::string::npos);
+  EXPECT_NE(msg.find("failed(100)"), std::string::npos);
+  EXPECT_NE(msg.find("tag=1"), std::string::npos);
+  EXPECT_NE(msg.find("failed(46)"), std::string::npos);
+}


### PR DESCRIPTION
## [0.53.6] - 2026-03-13

### Added
  - **Standalone core-to-core latency analysis mode (`-analyze-core2core`)**: Added a dedicated two-thread cache-line handoff benchmark mode that runs outside standard benchmark orchestration and supports optional `-output <file>`, `-count <count>`, and `-latency-samples <count>`.
  - **Core-to-core scenario reporting with scheduler hints**: New mode executes `no_affinity_hint`, `same_affinity_tag`, and `different_affinity_tags` scenarios, reports round-trip latency, one-way estimate, sample distribution statistics (P50/P90/P95/P99/stddev/min/max), and per-thread QoS/affinity hint status.
  - **Core-to-core JSON export**: Added mode-specific JSON payload under `core_to_core_latency` including loop values, sample distributions, computed statistics, and thread-hint application results.

### Changed
  - **CLI help text extended for standalone core-to-core mode**: `-h/--help` now documents `-analyze-core2core` and its allowed option set.
  - **Core-to-core handoff loop uses dedicated ARM64 assembly kernels**: Standalone `-analyze-core2core` now executes initiator/responder token ping-pong rounds through dedicated assembly routines, while keeping the existing mode interface, reporting, and JSON output structure.
  - **Refactored standalone TLB analysis module into smaller units**: Split previous `src/benchmark/analysis.cpp` into focused files: `src/benchmark/tlb_analysis.cpp` (orchestration), `src/benchmark/tlb_boundary_detector.cpp` (boundary detection and confidence logic), and `src/benchmark/tlb_analysis_json.cpp` (JSON serialization).
  - **Renamed TLB analysis interface/header**: Renamed `src/benchmark/analysis.h` to `src/benchmark/tlb_analysis.h` and updated includes/references accordingly (`main.cpp`, tests, and docs).
  - **Build wiring updated for new TLB analysis files**: Updated benchmark source list in `Makefile` to compile/link the new `tlb_analysis*` and `tlb_boundary_detector` units.