### PR TITLE
Version 0.53.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.53.9] - 2026-xx-xx
+
+### Changed
+  - **Centralized user-facing message strings**: Moved three remaining hardcoded user-facing strings to the Messages system:
+    - Timer creation failure error (`main.cpp:95`) now uses `Messages::error_timer_creation_failed()`
+    - JSON output success message (`file_writer.cpp:143`) now uses `Messages::msg_results_saved_to()`
+    - Pattern benchmark loop progress (`pattern_statistics_manager.cpp:134`) now uses `Messages::msg_pattern_benchmark_loop_completed()`
+  - **Test coverage for new message functions**: Added test cases for all three new message functions in `tests/test_messages.cpp`.
+
 ## [0.53.8] - 2026-03-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.53.9] - 2026-xx-xx
+## [0.53.9] - 2026-03-18
 
 ### Changed
   - **Centralized user-facing message strings**: Moved three remaining hardcoded user-facing strings to the Messages system:
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - JSON output success message (`file_writer.cpp:143`) now uses `Messages::msg_results_saved_to()`
     - Pattern benchmark loop progress (`pattern_statistics_manager.cpp:134`) now uses `Messages::msg_pattern_benchmark_loop_completed()`
   - **Test coverage for new message functions**: Added test cases for all three new message functions in `tests/test_messages.cpp`.
+  - **DRY cleanup across benchmarks, warmup, and tests**: Extracted shared helpers to remove duplicated latency, warmup, pattern, and test setup code.
 
 ## [0.53.8] - 2026-03-14
 

--- a/main.cpp
+++ b/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
   auto timer_opt = HighResTimer::create();
   if (!timer_opt) {
     std::cerr << Messages::error_prefix()
-              << "Failed to create high-resolution timer. Exiting."
+              << Messages::error_timer_creation_failed()
               << std::endl;
     return EXIT_FAILURE;
   }

--- a/src/benchmark/latency_tests.cpp
+++ b/src/benchmark/latency_tests.cpp
@@ -95,6 +95,25 @@ static double run_latency_measurement(uintptr_t* lat_start_ptr,
 }
 
 /**
+ * @brief Shared wrapper for latency benchmarks.
+ *
+ * Performs common validation and pointer conversion before dispatching to
+ * run_latency_measurement().
+ */
+static double run_latency_test_common(void* buffer,
+                                      size_t num_accesses,
+                                      HighResTimer& timer,
+                                      std::vector<double>* latency_samples,
+                                      int sample_count) {
+  if (num_accesses == 0) {
+    return 0.0;
+  }
+
+  uintptr_t* lat_start_ptr = static_cast<uintptr_t*>(buffer);
+  return run_latency_measurement(lat_start_ptr, num_accesses, timer, latency_samples, sample_count);
+}
+
+/**
  * @brief Executes the single-threaded memory latency benchmark.
  *
  * Measures memory access latency using pointer-chasing through a randomized circular
@@ -130,16 +149,8 @@ static double run_latency_measurement(uintptr_t* lat_start_ptr,
  * @see setup_latency_chain() for buffer initialization
  */
 double run_latency_test(void *buffer, size_t num_accesses, HighResTimer &timer,
-                         std::vector<double> *latency_samples, int sample_count) {
-  // Early validation: return 0 if no accesses requested
-  if (num_accesses == 0) {
-    return 0.0;
-  }
-  
-  // Get the starting address of the pointer chain.
-  uintptr_t *lat_start_ptr = static_cast<uintptr_t *>(buffer);
-
-  return run_latency_measurement(lat_start_ptr, num_accesses, timer, latency_samples, sample_count);
+                          std::vector<double> *latency_samples, int sample_count) {
+  return run_latency_test_common(buffer, num_accesses, timer, latency_samples, sample_count);
 }
 
 /**
@@ -180,15 +191,7 @@ double run_latency_test(void *buffer, size_t num_accesses, HighResTimer &timer,
  * @see setup_latency_chain() for buffer initialization
  */
 double run_cache_latency_test(void *buffer, size_t buffer_size, size_t num_accesses, HighResTimer &timer,
-                               std::vector<double> *latency_samples, int sample_count) {
-  // Early validation: return 0 if no accesses requested
-  if (num_accesses == 0) {
-    return 0.0;
-  }
-  
-  // Get the starting address of the pointer chain.
-  uintptr_t *lat_start_ptr = static_cast<uintptr_t *>(buffer);
-
+                                std::vector<double> *latency_samples, int sample_count) {
   (void)buffer_size;
-  return run_latency_measurement(lat_start_ptr, num_accesses, timer, latency_samples, sample_count);
+  return run_latency_test_common(buffer, num_accesses, timer, latency_samples, sample_count);
 }

--- a/src/benchmark/parallel_test_framework.h
+++ b/src/benchmark/parallel_test_framework.h
@@ -114,6 +114,67 @@ inline std::vector<size_t> build_aligned_chunk_boundaries(void* alignment_base, 
 }
 
 /**
+ * @brief Shared parallel test runner for single-buffer and copy variants.
+ * @tparam MakeThreadFunction Function type creating a worker callable for std::thread
+ * @param alignment_base Base pointer used for chunk-boundary alignment
+ * @param size Total size of the covered range in bytes
+ * @param iterations Number of operation iterations executed by each worker
+ * @param num_threads Number of worker threads to launch
+ * @param timer Reference to high-resolution timer for measuring execution time
+ * @param make_thread Function that builds a worker callable for one chunk
+ * @return Total duration in seconds, or 0.0 if no work was performed
+ */
+template<typename MakeThreadFunction>
+double run_parallel_test_common(void* alignment_base, size_t size, int iterations, int num_threads,
+                                HighResTimer& timer, MakeThreadFunction make_thread) {
+  // Early validation: return 0.0 if no work to do or invalid thread count.
+  // This avoids unnecessary setup and prevents division-by-zero in partitioning.
+  if (size == 0 || num_threads <= 0) {
+    return 0.0;
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(static_cast<size_t>(num_threads));  // Pre-allocate vector space for threads.
+
+  std::mutex start_mutex;
+  std::condition_variable start_cv;
+  bool start_flag = false;  // Gate so timing starts after threads are ready
+
+  // Build contiguous chunk boundaries with aligned internal split points.
+  std::vector<size_t> boundaries = build_aligned_chunk_boundaries(alignment_base, size, num_threads);
+
+  // Launch threads once; each handles its chunk for all iterations.
+  for (size_t t = 0; t < static_cast<size_t>(num_threads); ++t) {
+    size_t chunk_start_offset = boundaries[t];
+    size_t chunk_end_offset = boundaries[t + 1];
+    if (chunk_end_offset <= chunk_start_offset) {
+      continue;
+    }
+
+    size_t thread_chunk_size = chunk_end_offset - chunk_start_offset;
+    threads.emplace_back(make_thread(chunk_start_offset, thread_chunk_size, iterations, start_mutex, start_cv,
+                                     start_flag));
+  }
+
+  // Check if any threads were created. If all chunks were zero after alignment,
+  // no threads were created and we should return 0.0 to avoid misleading timer measurements.
+  if (threads.empty()) {
+    return 0.0;  // No threads created (all chunks were zero after alignment)
+  }
+
+  {
+    std::unique_lock<std::mutex> lk(start_mutex);
+    timer.start();  // Start timing after all threads are created and waiting.
+    start_flag = true;
+  }
+  start_cv.notify_all();
+
+  join_threads(threads);           // Wait for all threads to finish (joined once after all iterations).
+  double duration = timer.stop();  // Stop timing after all work.
+  return duration;                 // Return total time elapsed.
+}
+
+/**
  * @brief Run a parallel test with automatic work distribution across threads
  * @tparam WorkFunction Function type for per-thread work (void(void* chunk_start, size_t chunk_size, int iterations))
  * @param buffer Pointer to the memory buffer to operate on
@@ -137,37 +198,14 @@ inline std::vector<size_t> build_aligned_chunk_boundaries(void* alignment_base, 
 template<typename WorkFunction>
 double run_parallel_test(void *buffer, size_t size, int iterations, int num_threads, HighResTimer &timer,
                          WorkFunction work_function, const char *thread_name) {
-  // Early validation: return 0.0 if no work to do or invalid thread count.
-  // This avoids unnecessary setup and prevents division-by-zero in partitioning.
-  if (size == 0 || num_threads <= 0) {
-    return 0.0;
-  }
-
-  std::vector<std::thread> threads;
-  threads.reserve(static_cast<size_t>(num_threads));  // Pre-allocate vector space for threads.
-
-  std::mutex start_mutex;
-  std::condition_variable start_cv;
-  bool start_flag = false;  // Gate so timing starts after threads are ready
-
-  // Build contiguous chunk boundaries with aligned internal split points.
-  std::vector<size_t> boundaries = build_aligned_chunk_boundaries(buffer, size, num_threads);
-
-  // Launch threads once; each handles its chunk for all iterations.
   char* buffer_start = static_cast<char*>(buffer);
-  for (size_t t = 0; t < static_cast<size_t>(num_threads); ++t) {
-    size_t chunk_start_offset = boundaries[t];
-    size_t chunk_end_offset = boundaries[t + 1];
-    if (chunk_end_offset <= chunk_start_offset) {
-      continue;
-    }
-
+  auto make_thread = [buffer_start, work_function, thread_name](size_t chunk_start_offset, size_t thread_chunk_size,
+                                                                 int iterations_local, std::mutex& start_mutex,
+                                                                 std::condition_variable& start_cv,
+                                                                 bool& start_flag) {
     char* thread_chunk_start = buffer_start + chunk_start_offset;
-    size_t thread_chunk_size = chunk_end_offset - chunk_start_offset;
-     
-    // iterations loop inside thread lambda for re-use (avoids per-iteration creation).
-    threads.emplace_back([thread_chunk_start, thread_chunk_size, iterations, &start_mutex, &start_cv,
-                          &start_flag, work_function, thread_name]() {
+    return [thread_chunk_start, thread_chunk_size, iterations_local, &start_mutex, &start_cv, &start_flag,
+            work_function, thread_name]() {
       // Set QoS for this worker thread
       kern_return_t qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
       if (qos_ret != KERN_SUCCESS) {
@@ -181,26 +219,11 @@ double run_parallel_test(void *buffer, size_t size, int iterations, int num_thre
       }
 
       // Execute the work function for this chunk with aligned pointer
-      work_function(thread_chunk_start, thread_chunk_size, iterations);
-    });
-  }
+      work_function(thread_chunk_start, thread_chunk_size, iterations_local);
+    };
+  };
 
-  // Check if any threads were created. If all chunks were zero after alignment,
-  // no threads were created and we should return 0.0 to avoid misleading timer measurements.
-  if (threads.empty()) {
-    return 0.0;  // No threads created (all chunks were zero after alignment)
-  }
-
-  {
-    std::unique_lock<std::mutex> lk(start_mutex);
-    timer.start();   // Start timing after all threads are created and waiting.
-    start_flag = true;
-  }
-  start_cv.notify_all();
-
-  join_threads(threads);           // Wait for all threads to finish (joined once after all iterations).
-  double duration = timer.stop();  // Stop timing after all work.
-  return duration;  // Return total time elapsed.
+  return run_parallel_test_common(buffer, size, iterations, num_threads, timer, make_thread);
 }
 
 /**
@@ -228,40 +251,16 @@ double run_parallel_test(void *buffer, size_t size, int iterations, int num_thre
  */
 template<typename WorkFunction>
 double run_parallel_test_copy(void *dst, void *src, size_t size, int iterations, int num_threads, HighResTimer &timer,
-                                WorkFunction work_function, const char *thread_name) {
-  // Early validation: return 0.0 if no work to do or invalid thread count.
-  // This avoids unnecessary setup and prevents division-by-zero in partitioning.
-  if (size == 0 || num_threads <= 0) {
-    return 0.0;
-  }
-
-  std::vector<std::thread> threads;
-  threads.reserve(static_cast<size_t>(num_threads));  // Pre-allocate vector space for threads.
-
-  std::mutex start_mutex;
-  std::condition_variable start_cv;
-  bool start_flag = false;  // Gate so timing starts after threads are ready
-
-  // Build contiguous chunk boundaries using destination alignment for false-sharing mitigation.
-  std::vector<size_t> boundaries = build_aligned_chunk_boundaries(dst, size, num_threads);
-
-  // Launch threads once; each handles its chunk for all iterations.
+                                 WorkFunction work_function, const char *thread_name) {
   char* dst_start = static_cast<char*>(dst);
   char* src_start = static_cast<char*>(src);
-  for (size_t t = 0; t < static_cast<size_t>(num_threads); ++t) {
-    size_t chunk_start_offset = boundaries[t];
-    size_t chunk_end_offset = boundaries[t + 1];
-    if (chunk_end_offset <= chunk_start_offset) {
-      continue;
-    }
-
+  auto make_thread = [dst_start, src_start, work_function,
+                      thread_name](size_t chunk_start_offset, size_t thread_chunk_size, int iterations_local,
+                                   std::mutex& start_mutex, std::condition_variable& start_cv, bool& start_flag) {
     char* thread_dst_chunk = dst_start + chunk_start_offset;
     char* thread_src_chunk = src_start + chunk_start_offset;
-    size_t thread_chunk_size = chunk_end_offset - chunk_start_offset;
-     
-    // iterations loop inside thread lambda for re-use (avoids per-iteration creation).
-    threads.emplace_back([thread_dst_chunk, thread_src_chunk, thread_chunk_size, iterations, &start_mutex, &start_cv,
-                          &start_flag, work_function, thread_name]() {
+    return [thread_dst_chunk, thread_src_chunk, thread_chunk_size, iterations_local, &start_mutex, &start_cv,
+            &start_flag, work_function, thread_name]() {
       // Set QoS for this worker thread
       kern_return_t qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
       if (qos_ret != KERN_SUCCESS) {
@@ -275,26 +274,11 @@ double run_parallel_test_copy(void *dst, void *src, size_t size, int iterations,
       }
 
       // Execute the work function for this chunk with aligned pointers
-      work_function(thread_dst_chunk, thread_src_chunk, thread_chunk_size, iterations);
-    });
-  }
+      work_function(thread_dst_chunk, thread_src_chunk, thread_chunk_size, iterations_local);
+    };
+  };
 
-  // Check if any threads were created. If all chunks were zero after alignment,
-  // no threads were created and we should return 0.0 to avoid misleading timer measurements.
-  if (threads.empty()) {
-    return 0.0;  // No threads created (all chunks were zero after alignment)
-  }
-
-  {
-    std::unique_lock<std::mutex> lk(start_mutex);
-    timer.start();   // Start timing after all threads are created and waiting.
-    start_flag = true;
-  }
-  start_cv.notify_all();
-
-  join_threads(threads);           // Wait for all threads to finish (joined once after all iterations).
-  double duration = timer.stop();  // Stop timing after all work.
-  return duration;  // Return total time elapsed.
+  return run_parallel_test_common(dst, size, iterations, num_threads, timer, make_thread);
 }
 
 #endif // PARALLEL_TEST_FRAMEWORK_H

--- a/src/core/config/version.h
+++ b/src/core/config/version.h
@@ -29,6 +29,6 @@
  * @def SOFTVERSION
  * @brief Software version number (semantic versioning format as string)
  */
-#define SOFTVERSION "0.53.8"
+#define SOFTVERSION "0.53.9"
 
 #endif // VERSION_H

--- a/src/output/console/messages/error_messages.cpp
+++ b/src/output/console/messages/error_messages.cpp
@@ -169,6 +169,11 @@ const std::string& error_tlb_analysis_timer_creation_failed() {
   return msg;
 }
 
+const std::string& error_timer_creation_failed() {
+  static const std::string msg = "Failed to create high-resolution timer. Exiting.";
+  return msg;
+}
+
 std::string error_tlb_analysis_invalid_measurement(size_t locality_kb, int loop_number) {
   std::ostringstream oss;
   oss << "Invalid latency measurement during TLB analysis (locality=" << locality_kb

--- a/src/output/console/messages/messages_api.h
+++ b/src/output/console/messages/messages_api.h
@@ -74,6 +74,7 @@ const std::string& error_analyze_core_to_core_must_be_used_alone();
 const std::string& error_core_to_core_timer_creation_failed();
 const std::string& error_tlb_analysis_insufficient_memory();
 const std::string& error_tlb_analysis_timer_creation_failed();
+const std::string& error_timer_creation_failed();
 std::string error_tlb_analysis_invalid_measurement(size_t locality_kb, int loop_number);
 std::string error_mmap_failed(const std::string& buffer_name);
 std::string error_madvise_failed(const std::string& buffer_name);
@@ -159,6 +160,8 @@ std::string info_custom_cache_rounded_up(unsigned long original_kb, unsigned lon
 const std::string& msg_running_benchmarks();
 std::string msg_done_total_time(double total_time_sec);
 const std::string& msg_running_pattern_benchmarks();
+std::string msg_pattern_benchmark_loop_completed(int current_loop, int total_loops);
+std::string msg_results_saved_to(const std::string& file_path);
 const std::string& msg_running_tlb_analysis();
 const std::string& msg_running_core_to_core_analysis();
 std::string msg_core_to_core_scenario_progress(size_t current_loop,

--- a/src/output/console/messages/program_messages.cpp
+++ b/src/output/console/messages/program_messages.cpp
@@ -47,6 +47,16 @@ const std::string& msg_running_pattern_benchmarks() {
   return msg;
 }
 
+std::string msg_pattern_benchmark_loop_completed(int current_loop, int total_loops) {
+  std::ostringstream oss;
+  oss << "Pattern benchmarks - Loop " << current_loop << "/" << total_loops << " completed";
+  return oss.str();
+}
+
+std::string msg_results_saved_to(const std::string& file_path) {
+  return "Results saved to: " + file_path;
+}
+
 const std::string& msg_running_tlb_analysis() {
   static const std::string msg = "\nRunning standalone TLB analysis...";
   return msg;

--- a/src/output/json/json_output/file_writer.cpp
+++ b/src/output/json/json_output/file_writer.cpp
@@ -140,7 +140,7 @@ int write_json_to_file(const std::filesystem::path& file_path, const nlohmann::o
       return EXIT_FAILURE;
     }
     
-    std::cout << "Results saved to: " << file_path << std::endl;
+    std::cout << Messages::msg_results_saved_to(file_path.string()) << std::endl;
   } catch (const std::filesystem::filesystem_error& e) {
     // Clean up temp file if it exists
     std::error_code ec;

--- a/src/pattern_benchmark/helpers.cpp
+++ b/src/pattern_benchmark/helpers.cpp
@@ -39,6 +39,40 @@
 // Helper Functions for Pattern Tests
 // ============================================================================
 
+namespace {
+
+inline bool calculate_strided_chunk_params(size_t chunk_size, size_t stride,
+                                           size_t& effective_size,
+                                           size_t& num_accesses) {
+  using namespace Constants;
+
+  if (chunk_size <= PATTERN_ACCESS_SIZE_BYTES) {
+    return false;
+  }
+
+  effective_size = chunk_size - PATTERN_ACCESS_SIZE_BYTES;
+  num_accesses = (effective_size + stride - 1) / stride;
+  return true;
+}
+
+inline void build_random_chunk_indices(const std::vector<size_t>& indices,
+                                       size_t chunk_offset,
+                                       size_t chunk_size,
+                                       std::vector<size_t>& chunk_indices) {
+  using namespace Constants;
+
+  chunk_indices.reserve(indices.size() / 4);
+
+  size_t chunk_end = chunk_offset + chunk_size;
+  for (size_t idx : indices) {
+    if (idx >= chunk_offset && idx < chunk_end - PATTERN_ACCESS_SIZE_BYTES) {
+      chunk_indices.push_back(idx - chunk_offset);
+    }
+  }
+}
+
+}  // namespace
+
 // Helper function to run a pattern read test (multi-threaded)
 double run_pattern_read_test(void* buffer, size_t size, int iterations,
                              uint64_t (*read_func)(const void*, size_t),
@@ -98,14 +132,11 @@ double run_pattern_read_strided_test(void* buffer, size_t size, size_t stride, i
   auto strided_read_work = [&checksum, stride](char *chunk_start, size_t chunk_size, int iters) {
     uint64_t local_checksum = 0;
 
-    // Calculate effective size (accounting for access size)
-    if (chunk_size <= PATTERN_ACCESS_SIZE_BYTES) {
-      return;  // Skip if chunk too small
+    size_t effective_size = 0;
+    size_t num_accesses = 0;
+    if (!calculate_strided_chunk_params(chunk_size, stride, effective_size, num_accesses)) {
+      return;
     }
-    size_t effective_size = chunk_size - PATTERN_ACCESS_SIZE_BYTES;
-
-    // Calculate number of strided accesses for this chunk
-    size_t num_accesses = (effective_size + stride - 1) / stride;  // Ceiling division
 
     for (int i = 0; i < iters; ++i) {
       uint64_t result = memory_read_strided_loop_asm(chunk_start, effective_size, stride, num_accesses);
@@ -124,14 +155,11 @@ double run_pattern_write_strided_test(void* buffer, size_t size, size_t stride, 
 
   // Create work function that captures stride
   auto strided_write_work = [stride](char *chunk_start, size_t chunk_size, int iters) {
-    // Calculate effective size (accounting for access size)
-    if (chunk_size <= PATTERN_ACCESS_SIZE_BYTES) {
-      return;  // Skip if chunk too small
+    size_t effective_size = 0;
+    size_t num_accesses = 0;
+    if (!calculate_strided_chunk_params(chunk_size, stride, effective_size, num_accesses)) {
+      return;
     }
-    size_t effective_size = chunk_size - PATTERN_ACCESS_SIZE_BYTES;
-
-    // Calculate number of strided accesses for this chunk
-    size_t num_accesses = (effective_size + stride - 1) / stride;  // Ceiling division
 
     for (int i = 0; i < iters; ++i) {
       memory_write_strided_loop_asm(chunk_start, effective_size, stride, num_accesses);
@@ -148,14 +176,11 @@ double run_pattern_copy_strided_test(void* dst, void* src, size_t size, size_t s
 
   // Create work function that captures stride
   auto strided_copy_work = [stride](char *dst_chunk, char *src_chunk, size_t chunk_size, int iters) {
-    // Calculate effective size (accounting for access size)
-    if (chunk_size <= PATTERN_ACCESS_SIZE_BYTES) {
-      return;  // Skip if chunk too small
+    size_t effective_size = 0;
+    size_t num_accesses = 0;
+    if (!calculate_strided_chunk_params(chunk_size, stride, effective_size, num_accesses)) {
+      return;
     }
-    size_t effective_size = chunk_size - PATTERN_ACCESS_SIZE_BYTES;
-
-    // Calculate number of strided accesses for this chunk
-    size_t num_accesses = (effective_size + stride - 1) / stride;  // Ceiling division
 
     for (int i = 0; i < iters; ++i) {
       memory_copy_strided_loop_asm(dst_chunk, src_chunk, effective_size, stride, num_accesses);
@@ -181,19 +206,8 @@ double run_pattern_read_random_test(void* buffer, const std::vector<size_t>& ind
 
     // Calculate this chunk's offset from buffer start
     size_t chunk_offset = chunk_start - buffer_start;
-    size_t chunk_end = chunk_offset + chunk_size;
-
-    // Filter indices that fall within this chunk's range
     std::vector<size_t> chunk_indices;
-    chunk_indices.reserve(indices.size() / 4);  // Estimate
-
-    for (size_t idx : indices) {
-      // Check if this index falls within our chunk
-      if (idx >= chunk_offset && idx < chunk_end - PATTERN_ACCESS_SIZE_BYTES) {
-        // Convert to chunk-relative offset
-        chunk_indices.push_back(idx - chunk_offset);
-      }
-    }
+    build_random_chunk_indices(indices, chunk_offset, chunk_size, chunk_indices);
 
     // Skip if no valid indices for this chunk
     if (chunk_indices.empty()) {
@@ -223,19 +237,8 @@ double run_pattern_write_random_test(void* buffer, const std::vector<size_t>& in
   auto random_write_work = [&indices, buffer_start](char *chunk_start, size_t chunk_size, int iters) {
     // Calculate this chunk's offset from buffer start
     size_t chunk_offset = chunk_start - buffer_start;
-    size_t chunk_end = chunk_offset + chunk_size;
-
-    // Filter indices that fall within this chunk's range
     std::vector<size_t> chunk_indices;
-    chunk_indices.reserve(indices.size() / 4);  // Estimate
-
-    for (size_t idx : indices) {
-      // Check if this index falls within our chunk
-      if (idx >= chunk_offset && idx < chunk_end - PATTERN_ACCESS_SIZE_BYTES) {
-        // Convert to chunk-relative offset
-        chunk_indices.push_back(idx - chunk_offset);
-      }
-    }
+    build_random_chunk_indices(indices, chunk_offset, chunk_size, chunk_indices);
 
     // Skip if no valid indices for this chunk
     if (chunk_indices.empty()) {
@@ -263,19 +266,8 @@ double run_pattern_copy_random_test(void* dst, void* src, const std::vector<size
                           char *dst_chunk, char *src_chunk, size_t chunk_size, int iters) {
     // Calculate this chunk's offset from buffer start
     size_t chunk_offset = dst_chunk - dst_buffer_start;
-    size_t chunk_end = chunk_offset + chunk_size;
-
-    // Filter indices that fall within this chunk's range
     std::vector<size_t> chunk_indices;
-    chunk_indices.reserve(indices.size() / 4);  // Estimate
-
-    for (size_t idx : indices) {
-      // Check if this index falls within our chunk
-      if (idx >= chunk_offset && idx < chunk_end - PATTERN_ACCESS_SIZE_BYTES) {
-        // Convert to chunk-relative offset
-        chunk_indices.push_back(idx - chunk_offset);
-      }
-    }
+    build_random_chunk_indices(indices, chunk_offset, chunk_size, chunk_indices);
 
     // Skip if no valid indices for this chunk
     if (chunk_indices.empty()) {

--- a/src/pattern_benchmark/pattern_statistics_manager.cpp
+++ b/src/pattern_benchmark/pattern_statistics_manager.cpp
@@ -131,7 +131,7 @@ int run_all_pattern_benchmarks(const BenchmarkBuffers& buffers, const BenchmarkC
       // Print simple progress message for each loop
       if (config.loop_count > 1) {
         std::cout << '\r' << std::flush;  // Clear progress indicator
-        std::cout << "Pattern benchmarks - Loop " << (loop + 1) << "/" << config.loop_count << " completed" << std::endl;
+        std::cout << Messages::msg_pattern_benchmark_loop_completed(loop + 1, config.loop_count) << std::endl;
       }
     } catch (const std::exception &e) {
       std::cerr << Messages::error_benchmark_loop(loop, e.what()) << std::endl;

--- a/src/warmup/basic_warmup.cpp
+++ b/src/warmup/basic_warmup.cpp
@@ -18,7 +18,6 @@
  * @brief Basic memory warmup functions
  */
 
-#include "utils/benchmark.h"  // Includes definitions for assembly loops etc.
 #include "warmup/warmup.h"
 #include "warmup/warmup_internal.h"
 
@@ -32,17 +31,7 @@
  */
 void warmup_read(void* buffer, size_t size, int num_threads, std::atomic<uint64_t>& dummy_checksum) {
   size_t warmup_size = calculate_warmup_size(size);
-  auto read_chunk_op = [](char* chunk_start, char* /* src_chunk */, size_t chunk_size, 
-                          std::atomic<uint64_t>* checksum) {
-    // Call the assembly read loop function (defined elsewhere).
-    uint64_t result = memory_read_loop_asm(chunk_start, chunk_size);
-    // Atomically combine the local checksum with the global dummy value.
-    // Using release memory order ensures proper visibility when threads complete.
-    if (checksum) {
-      checksum->fetch_xor(result, std::memory_order_release);
-    }
-  };
-  warmup_parallel(buffer, size, num_threads, read_chunk_op, true, nullptr, &dummy_checksum, warmup_size);
+  warmup_parallel(buffer, size, num_threads, warmup_read_chunk_op, true, nullptr, &dummy_checksum, warmup_size);
 }
 
 /**
@@ -54,11 +43,7 @@ void warmup_read(void* buffer, size_t size, int num_threads, std::atomic<uint64_
  */
 void warmup_write(void* buffer, size_t size, int num_threads) {
   size_t warmup_size = calculate_warmup_size(size);
-  auto write_chunk_op = [](char* chunk_start, char* /* src_chunk */, size_t chunk_size, 
-                           std::atomic<uint64_t>* /* checksum */) {
-    memory_write_loop_asm(chunk_start, chunk_size);
-  };
-  warmup_parallel(buffer, size, num_threads, write_chunk_op, true, nullptr, nullptr, warmup_size);
+  warmup_parallel(buffer, size, num_threads, warmup_write_chunk_op, true, nullptr, nullptr, warmup_size);
 }
 
 /**
@@ -71,10 +56,5 @@ void warmup_write(void* buffer, size_t size, int num_threads) {
  */
 void warmup_copy(void* dst, void* src, size_t size, int num_threads) {
   size_t warmup_size = calculate_warmup_size(size);
-  auto copy_chunk_op = [](char* dst_chunk, char* src_chunk, size_t chunk_size, 
-                          std::atomic<uint64_t>* /* checksum */) {
-    memory_copy_loop_asm(dst_chunk, src_chunk, chunk_size);
-  };
-  warmup_parallel(dst, size, num_threads, copy_chunk_op, true, src, nullptr, warmup_size);
+  warmup_parallel(dst, size, num_threads, warmup_copy_chunk_op, true, src, nullptr, warmup_size);
 }
-

--- a/src/warmup/cache_warmup.cpp
+++ b/src/warmup/cache_warmup.cpp
@@ -18,9 +18,6 @@
  * @brief Cache-specific warmup functions
  */
 
-#include <atomic>    // For std::atomic
-
-#include "utils/benchmark.h"  // Includes definitions for assembly loops etc.
 #include "warmup/warmup.h"
 #include "warmup/warmup_internal.h"
 
@@ -41,17 +38,7 @@ void warmup_cache_read(void* src_buffer, size_t size, int num_threads, std::atom
     return;
   }
   size_t warmup_size = size;
-  auto read_chunk_op = [](char* chunk_start, char* /* src_chunk */, size_t chunk_size, 
-                          std::atomic<uint64_t>* checksum) {
-    // Call the assembly read loop function (defined elsewhere).
-    uint64_t result = memory_read_loop_asm(chunk_start, chunk_size);
-    // Atomically combine the local checksum with the global dummy value.
-    // Using release memory order ensures proper visibility when threads complete.
-    if (checksum) {
-      checksum->fetch_xor(result, std::memory_order_release);
-    }
-  };
-  warmup_parallel(src_buffer, size, num_threads, read_chunk_op, true, nullptr, &dummy_checksum, warmup_size);
+  warmup_parallel(src_buffer, size, num_threads, warmup_read_chunk_op, true, nullptr, &dummy_checksum, warmup_size);
 }
 
 /**
@@ -70,11 +57,7 @@ void warmup_cache_write(void* dst_buffer, size_t size, int num_threads) {
     return;
   }
   size_t warmup_size = size;
-  auto write_chunk_op = [](char* chunk_start, char* /* src_chunk */, size_t chunk_size, 
-                           std::atomic<uint64_t>* /* checksum */) {
-    memory_write_loop_asm(chunk_start, chunk_size);
-  };
-  warmup_parallel(dst_buffer, size, num_threads, write_chunk_op, true, nullptr, nullptr, warmup_size);
+  warmup_parallel(dst_buffer, size, num_threads, warmup_write_chunk_op, true, nullptr, nullptr, warmup_size);
 }
 
 /**
@@ -94,10 +77,5 @@ void warmup_cache_copy(void* dst, void* src, size_t size, int num_threads) {
     return;
   }
   size_t warmup_size = size;
-  auto copy_chunk_op = [](char* dst_chunk, char* src_chunk, size_t chunk_size, 
-                          std::atomic<uint64_t>* /* checksum */) {
-    memory_copy_loop_asm(dst_chunk, src_chunk, chunk_size);
-  };
-  warmup_parallel(dst, size, num_threads, copy_chunk_op, true, src, nullptr, warmup_size);
+  warmup_parallel(dst, size, num_threads, warmup_copy_chunk_op, true, src, nullptr, warmup_size);
 }
-

--- a/src/warmup/pattern_warmup.cpp
+++ b/src/warmup/pattern_warmup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Timo Heimonen <timo.heimonen@proton.me>
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -32,6 +32,90 @@
 #include "warmup/warmup.h"
 #include "warmup/warmup_internal.h"
 
+namespace {
+
+bool validate_strided_warmup_stride(size_t stride, size_t size) {
+  if (stride < 32) {
+    std::cerr << Messages::error_prefix() << Messages::error_stride_too_small() << std::endl;
+    return false;
+  }
+  if (stride > size) {
+    std::cerr << Messages::error_prefix() << Messages::error_stride_too_large(stride, size) << std::endl;
+    return false;
+  }
+  if (stride % 32 != 0) {
+    std::cerr << Messages::warning_prefix() << Messages::warning_stride_not_aligned(stride) << std::endl;
+  }
+  return true;
+}
+
+bool validate_random_warmup_indices(const std::vector<size_t>& indices) {
+  if (indices.empty()) {
+    std::cerr << Messages::error_prefix() << Messages::error_indices_empty() << std::endl;
+    return false;
+  }
+
+  size_t sample_size = (indices.size() < 100) ? indices.size() : 100;
+  for (size_t i = 0; i < sample_size; ++i) {
+    if (indices[i] % 32 != 0) {
+      std::cerr << Messages::error_prefix() << Messages::error_index_not_aligned(i, indices[i]) << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template<typename RandomOp>
+void run_random_warmup_operation(const std::vector<size_t>& indices, int num_threads, RandomOp operation) {
+  if (!validate_random_warmup_indices(indices)) {
+    return;
+  }
+
+  if (num_threads <= 0) {
+    return;
+  }
+
+  if (num_threads == 1 || indices.size() <= static_cast<size_t>(num_threads)) {
+    operation(indices.data(), indices.size());
+    return;
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+
+  size_t indices_per_thread = indices.size() / num_threads;
+  size_t remainder = indices.size() % num_threads;
+
+  size_t offset = 0;
+  for (int t = 0; t < num_threads; ++t) {
+    size_t thread_count = indices_per_thread + (t < static_cast<int>(remainder) ? 1 : 0);
+    if (thread_count == 0 || offset >= indices.size()) continue;
+
+    size_t start_idx = offset;
+    size_t end_idx = offset + thread_count;
+    if (end_idx > indices.size()) end_idx = indices.size();
+    offset = end_idx;
+
+    std::vector<size_t> thread_indices(indices.begin() + start_idx, indices.begin() + end_idx);
+
+    threads.emplace_back([thread_indices = std::move(thread_indices), operation]() {
+      kern_return_t qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+      if (qos_ret != KERN_SUCCESS) {
+        std::cerr << Messages::warning_prefix() << Messages::warning_qos_failed_worker_thread(qos_ret) << std::endl;
+      }
+
+      if (!thread_indices.empty()) {
+        operation(thread_indices.data(), thread_indices.size());
+      }
+    });
+  }
+
+  join_threads(threads);
+}
+
+}  // namespace
+
 /**
  * @brief Warms up memory by reading from the buffer using strided access pattern.
  *
@@ -42,17 +126,8 @@
  * @param dummy_checksum Atomic variable to accumulate a dummy result (prevents optimization)
  */
 void warmup_read_strided(void* buffer, size_t size, size_t stride, int num_threads, std::atomic<uint64_t>& dummy_checksum) {
-  // Validate stride
-  if (stride < 32) {
-    std::cerr << Messages::error_prefix() << Messages::error_stride_too_small() << std::endl;
+  if (!validate_strided_warmup_stride(stride, size)) {
     return;
-  }
-  if (stride > size) {
-    std::cerr << Messages::error_prefix() << Messages::error_stride_too_large(stride, size) << std::endl;
-    return;
-  }
-  if (stride % 32 != 0) {
-    std::cerr << Messages::warning_prefix() << Messages::warning_stride_not_aligned(stride) << std::endl;
   }
   
   size_t warmup_size = calculate_warmup_size(size);
@@ -77,17 +152,8 @@ void warmup_read_strided(void* buffer, size_t size, size_t stride, int num_threa
  * @param num_threads Number of concurrent threads to use
  */
 void warmup_write_strided(void* buffer, size_t size, size_t stride, int num_threads) {
-  // Validate stride
-  if (stride < 32) {
-    std::cerr << Messages::error_prefix() << Messages::error_stride_too_small() << std::endl;
+  if (!validate_strided_warmup_stride(stride, size)) {
     return;
-  }
-  if (stride > size) {
-    std::cerr << Messages::error_prefix() << Messages::error_stride_too_large(stride, size) << std::endl;
-    return;
-  }
-  if (stride % 32 != 0) {
-    std::cerr << Messages::warning_prefix() << Messages::warning_stride_not_aligned(stride) << std::endl;
   }
   
   size_t warmup_size = calculate_warmup_size(size);
@@ -110,17 +176,8 @@ void warmup_write_strided(void* buffer, size_t size, size_t stride, int num_thre
  * @param num_threads Number of concurrent threads to use
  */
 void warmup_copy_strided(void* dst, void* src, size_t size, size_t stride, int num_threads) {
-  // Validate stride
-  if (stride < 32) {
-    std::cerr << Messages::error_prefix() << Messages::error_stride_too_small() << std::endl;
+  if (!validate_strided_warmup_stride(stride, size)) {
     return;
-  }
-  if (stride > size) {
-    std::cerr << Messages::error_prefix() << Messages::error_stride_too_large(stride, size) << std::endl;
-    return;
-  }
-  if (stride % 32 != 0) {
-    std::cerr << Messages::warning_prefix() << Messages::warning_stride_not_aligned(stride) << std::endl;
   }
   
   size_t warmup_size = calculate_warmup_size(size);
@@ -142,67 +199,11 @@ void warmup_copy_strided(void* dst, void* src, size_t size, size_t stride, int n
  * @param dummy_checksum Atomic variable to accumulate a dummy result (prevents optimization)
  */
 void warmup_read_random(void* buffer, const std::vector<size_t>& indices, int num_threads, std::atomic<uint64_t>& dummy_checksum) {
-  if (indices.empty()) {
-    std::cerr << Messages::error_prefix() << Messages::error_indices_empty() << std::endl;
-    return;
-  }
-  
-  // Validate indices (check first few as sample)
-  size_t sample_size = (indices.size() < 100) ? indices.size() : 100;
-  for (size_t i = 0; i < sample_size; ++i) {
-    if (indices[i] % 32 != 0) {
-      std::cerr << Messages::error_prefix() << Messages::error_index_not_aligned(i, indices[i]) << std::endl;
-      return;
-    }
-  }
-  
-  // Use the indices directly - they should already be validated by the caller
-  // For multi-threading, we'll split the indices across threads
-  // If num_threads is 0 or indices is empty, return early (already checked empty above)
-  if (num_threads <= 0) {
-    return;
-  }
-  
-  // For small index sets or single thread, just run directly
-  if (num_threads == 1 || indices.size() <= static_cast<size_t>(num_threads)) {
-    uint64_t result = memory_read_random_loop_asm(buffer, indices.data(), indices.size());
-    dummy_checksum.fetch_xor(result, std::memory_order_release);
-    return;
-  }
-  
-  std::vector<std::thread> threads;
-  threads.reserve(num_threads);
-  
-  size_t indices_per_thread = indices.size() / num_threads;
-  size_t remainder = indices.size() % num_threads;
-  
-  size_t offset = 0;
-  for (int t = 0; t < num_threads; ++t) {
-    size_t thread_count = indices_per_thread + (t < static_cast<int>(remainder) ? 1 : 0);
-    if (thread_count == 0 || offset >= indices.size()) continue;
-    
-    size_t start_idx = offset;
-    size_t end_idx = offset + thread_count;
-    if (end_idx > indices.size()) end_idx = indices.size();
-    offset = end_idx;
-    
-    // Create a copy of the indices for this thread to avoid race conditions
-    std::vector<size_t> thread_indices(indices.begin() + start_idx, indices.begin() + end_idx);
-    
-    threads.emplace_back([buffer, thread_indices, &dummy_checksum]() {
-      kern_return_t qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
-      if (qos_ret != KERN_SUCCESS) {
-        std::cerr << Messages::warning_prefix() << Messages::warning_qos_failed_worker_thread(qos_ret) << std::endl;
-      }
-      
-      if (!thread_indices.empty()) {
-        uint64_t result = memory_read_random_loop_asm(buffer, thread_indices.data(), thread_indices.size());
-        dummy_checksum.fetch_xor(result, std::memory_order_release);
-      }
-    });
-  }
-  
-  join_threads(threads);
+  run_random_warmup_operation(indices, num_threads,
+                              [buffer, &dummy_checksum](const size_t* random_indices, size_t random_count) {
+                                uint64_t result = memory_read_random_loop_asm(buffer, random_indices, random_count);
+                                dummy_checksum.fetch_xor(result, std::memory_order_release);
+                              });
 }
 
 /**
@@ -213,64 +214,10 @@ void warmup_read_random(void* buffer, const std::vector<size_t>& indices, int nu
  * @param num_threads Number of concurrent threads to use
  */
 void warmup_write_random(void* buffer, const std::vector<size_t>& indices, int num_threads) {
-  if (indices.empty()) {
-    std::cerr << Messages::error_prefix() << Messages::error_indices_empty() << std::endl;
-    return;
-  }
-  
-  // Validate indices (check first few as sample)
-  size_t sample_size = (indices.size() < 100) ? indices.size() : 100;
-  for (size_t i = 0; i < sample_size; ++i) {
-    if (indices[i] % 32 != 0) {
-      std::cerr << Messages::error_prefix() << Messages::error_index_not_aligned(i, indices[i]) << std::endl;
-      return;
-    }
-  }
-  
-  // Use the indices directly - they should already be validated by the caller
-  // For multi-threading, we'll split the indices across threads
-  if (num_threads <= 0) {
-    return;
-  }
-  
-  // For small index sets or single thread, just run directly
-  if (num_threads == 1 || indices.size() <= static_cast<size_t>(num_threads)) {
-    memory_write_random_loop_asm(buffer, indices.data(), indices.size());
-    return;
-  }
-  
-  std::vector<std::thread> threads;
-  threads.reserve(num_threads);
-  
-  size_t indices_per_thread = indices.size() / num_threads;
-  size_t remainder = indices.size() % num_threads;
-  
-  size_t offset = 0;
-  for (int t = 0; t < num_threads; ++t) {
-    size_t thread_count = indices_per_thread + (t < static_cast<int>(remainder) ? 1 : 0);
-    if (thread_count == 0 || offset >= indices.size()) continue;
-    
-    size_t start_idx = offset;
-    size_t end_idx = offset + thread_count;
-    if (end_idx > indices.size()) end_idx = indices.size();
-    offset = end_idx;
-    
-    // Create a copy of the indices for this thread to avoid race conditions
-    std::vector<size_t> thread_indices(indices.begin() + start_idx, indices.begin() + end_idx);
-    
-    threads.emplace_back([buffer, thread_indices]() {
-      kern_return_t qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
-      if (qos_ret != KERN_SUCCESS) {
-        std::cerr << Messages::warning_prefix() << Messages::warning_qos_failed_worker_thread(qos_ret) << std::endl;
-      }
-      
-      if (!thread_indices.empty()) {
-        memory_write_random_loop_asm(buffer, thread_indices.data(), thread_indices.size());
-      }
-    });
-  }
-  
-  join_threads(threads);
+  run_random_warmup_operation(indices, num_threads,
+                              [buffer](const size_t* random_indices, size_t random_count) {
+                                memory_write_random_loop_asm(buffer, random_indices, random_count);
+                              });
 }
 
 /**
@@ -282,62 +229,8 @@ void warmup_write_random(void* buffer, const std::vector<size_t>& indices, int n
  * @param num_threads Number of concurrent threads to use
  */
 void warmup_copy_random(void* dst, void* src, const std::vector<size_t>& indices, int num_threads) {
-  if (indices.empty()) {
-    std::cerr << Messages::error_prefix() << Messages::error_indices_empty() << std::endl;
-    return;
-  }
-  
-  // Validate indices (check first few as sample)
-  size_t sample_size = (indices.size() < 100) ? indices.size() : 100;
-  for (size_t i = 0; i < sample_size; ++i) {
-    if (indices[i] % 32 != 0) {
-      std::cerr << Messages::error_prefix() << Messages::error_index_not_aligned(i, indices[i]) << std::endl;
-      return;
-    }
-  }
-  
-  // Use the indices directly - they should already be validated by the caller
-  // For multi-threading, we'll split the indices across threads
-  if (num_threads <= 0) {
-    return;
-  }
-  
-  // For small index sets or single thread, just run directly
-  if (num_threads == 1 || indices.size() <= static_cast<size_t>(num_threads)) {
-    memory_copy_random_loop_asm(dst, src, indices.data(), indices.size());
-    return;
-  }
-  
-  std::vector<std::thread> threads;
-  threads.reserve(num_threads);
-  
-  size_t indices_per_thread = indices.size() / num_threads;
-  size_t remainder = indices.size() % num_threads;
-  
-  size_t offset = 0;
-  for (int t = 0; t < num_threads; ++t) {
-    size_t thread_count = indices_per_thread + (t < static_cast<int>(remainder) ? 1 : 0);
-    if (thread_count == 0 || offset >= indices.size()) continue;
-    
-    size_t start_idx = offset;
-    size_t end_idx = offset + thread_count;
-    if (end_idx > indices.size()) end_idx = indices.size();
-    offset = end_idx;
-    
-    // Create a copy of the indices for this thread to avoid race conditions
-    std::vector<size_t> thread_indices(indices.begin() + start_idx, indices.begin() + end_idx);
-    
-    threads.emplace_back([dst, src, thread_indices]() {
-      kern_return_t qos_ret = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
-      if (qos_ret != KERN_SUCCESS) {
-        std::cerr << Messages::warning_prefix() << Messages::warning_qos_failed_worker_thread(qos_ret) << std::endl;
-      }
-      
-      if (!thread_indices.empty()) {
-        memory_copy_random_loop_asm(dst, src, thread_indices.data(), thread_indices.size());
-      }
-    });
-  }
-  
-  join_threads(threads);
+  run_random_warmup_operation(indices, num_threads,
+                              [dst, src](const size_t* random_indices, size_t random_count) {
+                                memory_copy_random_loop_asm(dst, src, random_indices, random_count);
+                              });
 }

--- a/src/warmup/warmup_internal.h
+++ b/src/warmup/warmup_internal.h
@@ -49,6 +49,7 @@
 #include <mach/mach.h>
 #include <pthread/qos.h>
 
+#include "asm/asm_functions.h"
 #include "output/console/messages/messages_api.h"
 #include "core/memory/memory_utils.h"
 #include "core/config/constants.h"
@@ -76,6 +77,33 @@ inline size_t calculate_warmup_size(size_t buffer_size) {
   const size_t percent_warmup = static_cast<size_t>(buffer_size * 0.1);
   const size_t effective_warmup = (min_warmup > percent_warmup) ? min_warmup : percent_warmup;
   return (buffer_size < effective_warmup) ? buffer_size : effective_warmup;
+}
+
+/**
+ * @brief Shared chunk operation for warmup read paths.
+ */
+inline void warmup_read_chunk_op(char* chunk_start, char* /* src_chunk */, size_t chunk_size,
+                                 std::atomic<uint64_t>* checksum) {
+  uint64_t result = memory_read_loop_asm(chunk_start, chunk_size);
+  if (checksum) {
+    checksum->fetch_xor(result, std::memory_order_release);
+  }
+}
+
+/**
+ * @brief Shared chunk operation for warmup write paths.
+ */
+inline void warmup_write_chunk_op(char* chunk_start, char* /* src_chunk */, size_t chunk_size,
+                                  std::atomic<uint64_t>* /* checksum */) {
+  memory_write_loop_asm(chunk_start, chunk_size);
+}
+
+/**
+ * @brief Shared chunk operation for warmup copy paths.
+ */
+inline void warmup_copy_chunk_op(char* dst_chunk, char* src_chunk, size_t chunk_size,
+                                 std::atomic<uint64_t>* /* checksum */) {
+  memory_copy_loop_asm(dst_chunk, src_chunk, chunk_size);
 }
 
 // Generic parallel warmup function for multi-threaded operations.

--- a/tests/test_benchmark_executor.cpp
+++ b/tests/test_benchmark_executor.cpp
@@ -31,20 +31,14 @@
 #include "core/config/constants.h"
 #include "core/memory/buffer_manager.h"
 #include "core/memory/memory_utils.h"
-#include "core/system/system_info.h"
 #include "core/timing/timer.h"
+#include "test_config_helpers.h"
 
 namespace {
 
 BenchmarkConfig build_base_config() {
   BenchmarkConfig config;
-
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
 
   config.buffer_size = static_cast<size_t>(getpagesize());
   config.buffer_size_mb = 1;
@@ -125,8 +119,7 @@ TEST(BenchmarkExecutorTest, MainMemoryLatencyCollectsSamplesWhenConfigured) {
   config.latency_sample_count = 17;
 
   BenchmarkBuffers buffers;
-  ASSERT_EQ(allocate_all_buffers(config, buffers), EXIT_SUCCESS);
-  ASSERT_EQ(initialize_all_buffers(buffers, config), EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
 
   auto timer_opt = HighResTimer::create();
   ASSERT_TRUE(timer_opt.has_value());
@@ -149,8 +142,7 @@ TEST(BenchmarkExecutorTest, MainMemoryLatencySkipsAutoTlbBreakdownWhenLocalitySp
   config.latency_tlb_locality_bytes = static_cast<size_t>(16) * Constants::BYTES_PER_KB;
 
   BenchmarkBuffers buffers;
-  ASSERT_EQ(allocate_all_buffers(config, buffers), EXIT_SUCCESS);
-  ASSERT_EQ(initialize_all_buffers(buffers, config), EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
 
   auto timer_opt = HighResTimer::create();
   ASSERT_TRUE(timer_opt.has_value());
@@ -179,8 +171,7 @@ TEST(BenchmarkExecutorTest, MainMemoryLatencySkipsWhenMainLatencyDisabled) {
   calculate_access_counts(config);
 
   BenchmarkBuffers buffers;
-  ASSERT_EQ(allocate_all_buffers(config, buffers), EXIT_SUCCESS);
-  ASSERT_EQ(initialize_all_buffers(buffers, config), EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
 
   auto timer_opt = HighResTimer::create();
   ASSERT_TRUE(timer_opt.has_value());

--- a/tests/test_benchmark_runner.cpp
+++ b/tests/test_benchmark_runner.cpp
@@ -20,6 +20,8 @@
 #include "output/json/json_output/json_output_api.h"
 #include "utils/benchmark.h"
 #include "core/config/constants.h"
+#include "test_config_helpers.h"
+#include "test_statistics_helpers.h"
 #include <cstdlib>
 #include <cmath>     // std::isnan, std::isinf
 #include <unistd.h>  // getpagesize
@@ -64,13 +66,7 @@ TEST(BenchmarkRunnerTest, StatisticsClearing) {
   BenchmarkBuffers buffers;
   BenchmarkStatistics stats;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   // Set minimal config for testing
   config.buffer_size = getpagesize();  // Minimum size
@@ -82,14 +78,9 @@ TEST(BenchmarkRunnerTest, StatisticsClearing) {
   // Calculate buffer sizes and access counts (required for cache tests)
   calculate_buffer_sizes(config);
   calculate_access_counts(config);
-  
+
   // Allocate minimal buffers
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  // Initialize buffers
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   // Run with 0 loops - should just clear statistics
   int result = run_all_benchmarks(buffers, config, stats);
@@ -115,13 +106,7 @@ TEST(BenchmarkRunnerTest, StatisticsReservationIntegration) {
   BenchmarkBuffers buffers;
   BenchmarkStatistics stats;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   // Set config with loop_count > 0
   config.buffer_size = getpagesize();
@@ -133,14 +118,9 @@ TEST(BenchmarkRunnerTest, StatisticsReservationIntegration) {
   // Calculate buffer sizes and access counts (required for cache tests)
   calculate_buffer_sizes(config);
   calculate_access_counts(config);
-  
+
   // Allocate minimal buffers
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  // Initialize buffers
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   // Note: This will run actual benchmarks, which may take a moment
   // but tests the full integration
@@ -213,13 +193,7 @@ TEST(BenchmarkRunnerTest, ResultsValidation) {
   BenchmarkBuffers buffers;
   BenchmarkStatistics stats;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   // Set config with loop_count > 0
   config.buffer_size = getpagesize();
@@ -231,14 +205,9 @@ TEST(BenchmarkRunnerTest, ResultsValidation) {
   // Calculate buffer sizes and access counts (required for cache tests)
   calculate_buffer_sizes(config);
   calculate_access_counts(config);
-  
+
   // Allocate minimal buffers
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  // Initialize buffers
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   // Run benchmarks
   int result = run_all_benchmarks(buffers, config, stats);
@@ -285,43 +254,13 @@ TEST(BenchmarkRunnerTest, ResultsValidation) {
 }
 
 TEST(BenchmarkRunnerTest, StatisticsPrintsAutoTlbBreakdownMetrics) {
-  const int loop_count = 2;
-
-  const std::vector<double> empty;
   const std::vector<double> all_main_mem_latency = {15.0, 16.0};
   const std::vector<double> all_tlb_hit_latency = {14.0, 15.0};
   const std::vector<double> all_tlb_miss_latency = {90.0, 92.0};
   const std::vector<double> all_page_walk_penalty = {76.0, 77.0};
 
-  testing::internal::CaptureStdout();
-  print_statistics(loop_count,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   all_main_mem_latency,
-                   all_tlb_hit_latency,
-                   all_tlb_miss_latency,
-                   all_page_walk_penalty,
-                   false,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   empty,
-                   false,
-                   true);
-  const std::string output = testing::internal::GetCapturedStdout();
+  const std::string output = test_statistics_helpers::capture_auto_tlb_breakdown(
+      all_main_mem_latency, all_tlb_hit_latency, all_tlb_miss_latency, all_page_walk_penalty);
 
   EXPECT_NE(output.find("TLB Hit Latency (ns):"), std::string::npos);
   EXPECT_NE(output.find("TLB Miss Latency (ns):"), std::string::npos);

--- a/tests/test_buffer_manager.cpp
+++ b/tests/test_buffer_manager.cpp
@@ -18,6 +18,7 @@
 #include "core/config/config.h"
 #include "core/config/constants.h"
 #include "utils/benchmark.h"  // Declares system_info functions
+#include "test_config_helpers.h"
 #include <cstdlib>
 #include <limits>
 
@@ -29,13 +30,7 @@ TEST(BufferManagerTest, AllocateAllBuffersValid) {
   config.l2_buffer_size = 512 * 1024;  // 512 KB
   config.use_custom_cache_size = false;
   
-  // Initialize system info (needed for allocation)
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
   int result = allocate_all_buffers(config, buffers);
@@ -55,11 +50,7 @@ TEST(BufferManagerTest, AllocateAllBuffersCustomCache) {
   config.use_custom_cache_size = true;
   config.custom_buffer_size = 128 * 1024;  // 128 KB
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
+  initialize_system_info(config);
   config.custom_cache_size_bytes = config.custom_buffer_size;
   
   BenchmarkBuffers buffers;
@@ -80,13 +71,7 @@ TEST(BufferManagerTest, BufferHelperMethods) {
   config.l2_buffer_size = 512 * 1024;  // 512 KB
   config.use_custom_cache_size = false;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
   int result = allocate_all_buffers(config, buffers);
@@ -108,20 +93,10 @@ TEST(BufferManagerTest, InitializeAllBuffers) {
   config.l2_buffer_size = 512 * 1024;  // 512 KB
   config.use_custom_cache_size = false;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  EXPECT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
 }
 
 // Test that all buffers use non-cacheable allocation when flag is set
@@ -133,13 +108,7 @@ TEST(BufferManagerTest, AllocateAllBuffersNonCacheable) {
   config.use_custom_cache_size = false;
   config.use_non_cacheable = true;  // Enable non-cacheable allocation
   
-  // Initialize system info (needed for allocation)
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
   int result = allocate_all_buffers(config, buffers);
@@ -166,11 +135,7 @@ TEST(BufferManagerTest, AllocateAllBuffersNonCacheableCustomCache) {
   config.custom_buffer_size = 128 * 1024;  // 128 KB
   config.use_non_cacheable = true;  // Enable non-cacheable allocation
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
+  initialize_system_info(config);
   config.custom_cache_size_bytes = config.custom_buffer_size;
   
   BenchmarkBuffers buffers;
@@ -196,21 +161,11 @@ TEST(BufferManagerTest, InitializeAllBuffersNonCacheable) {
   config.use_custom_cache_size = false;
   config.use_non_cacheable = true;  // Enable non-cacheable allocation
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
   // Verify buffers can be initialized (tests that they're usable)
-  int init_result = initialize_all_buffers(buffers, config);
-  EXPECT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
 }
 
 // Test allocation failure when buffer_size is zero - should fail early with error message
@@ -221,13 +176,7 @@ TEST(BufferManagerTest, AllocateAllBuffersFirstBufferFails) {
   config.l2_buffer_size = 512 * 1024;
   config.use_custom_cache_size = false;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   testing::internal::CaptureStderr();
   BenchmarkBuffers buffers;
@@ -331,9 +280,7 @@ TEST(BufferManagerTest, InitializeAllBuffersOnlyLatencyWithMainDisabledAndCustom
   config.custom_num_accesses = Constants::CUSTOM_LATENCY_ACCESSES;
 
   BenchmarkBuffers buffers;
-  ASSERT_EQ(allocate_all_buffers(config, buffers), EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   EXPECT_EQ(buffers.lat_buffer(), nullptr);
   EXPECT_NE(buffers.custom_buffer(), nullptr);
-
-  EXPECT_EQ(initialize_all_buffers(buffers, config), EXIT_SUCCESS);
 }

--- a/tests/test_config_helpers.h
+++ b/tests/test_config_helpers.h
@@ -1,0 +1,38 @@
+#ifndef TEST_CONFIG_HELPERS_H
+#define TEST_CONFIG_HELPERS_H
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "core/config/config.h"
+#include "core/memory/buffer_manager.h"
+#include "utils/benchmark.h"
+
+inline void initialize_system_info(BenchmarkConfig& config) {
+  config.cpu_name = get_processor_name();
+  config.perf_cores = get_performance_cores();
+  config.eff_cores = get_efficiency_cores();
+  config.num_threads = get_total_logical_cores();
+  config.l1_cache_size = get_l1_cache_size();
+  config.l2_cache_size = get_l2_cache_size();
+}
+
+inline ::testing::AssertionResult allocate_and_initialize_buffers(BenchmarkConfig& config,
+                                                                  BenchmarkBuffers& buffers) {
+  const int alloc_result = allocate_all_buffers(config, buffers);
+  if (alloc_result != EXIT_SUCCESS) {
+    return ::testing::AssertionFailure()
+           << "allocate_all_buffers(config, buffers) failed with code " << alloc_result;
+  }
+
+  const int init_result = initialize_all_buffers(buffers, config);
+  if (init_result != EXIT_SUCCESS) {
+    return ::testing::AssertionFailure()
+           << "initialize_all_buffers(buffers, config) failed with code " << init_result;
+  }
+
+  return ::testing::AssertionSuccess();
+}
+
+#endif  // TEST_CONFIG_HELPERS_H

--- a/tests/test_messages.cpp
+++ b/tests/test_messages.cpp
@@ -302,6 +302,14 @@ TEST_F(MessagesErrorTest, ErrorBenchmarkTests) {
   EXPECT_EQ(msg, "Error during benchmark tests: test failure");
 }
 
+TEST_F(MessagesErrorTest, ErrorTimerCreationFailed) {
+  const std::string& msg = Messages::error_timer_creation_failed();
+  EXPECT_NE(msg.find("timer"), std::string::npos);
+  EXPECT_NE(msg.find("Failed"), std::string::npos);
+  // Verify it returns a stable reference (static string)
+  EXPECT_EQ(&msg, &Messages::error_timer_creation_failed());
+}
+
 // ============================================================================
 // Warning Messages Tests (using fixture)
 // ============================================================================
@@ -361,6 +369,26 @@ TEST_F(MessagesFormattingTest, MsgDoneTotalTime) {
   
   msg = Messages::msg_done_total_time(0.001);
   EXPECT_NE(msg.find("0.001"), std::string::npos);
+}
+
+TEST_F(MessagesFormattingTest, MsgResultsSavedTo) {
+  std::string msg = Messages::msg_results_saved_to("results.json");
+  EXPECT_NE(msg.find("Results saved to"), std::string::npos);
+  EXPECT_NE(msg.find("results.json"), std::string::npos);
+
+  msg = Messages::msg_results_saved_to("/tmp/out/bench.json");
+  EXPECT_NE(msg.find("/tmp/out/bench.json"), std::string::npos);
+}
+
+TEST_F(MessagesFormattingTest, MsgPatternBenchmarkLoopCompleted) {
+  std::string msg = Messages::msg_pattern_benchmark_loop_completed(3, 10);
+  EXPECT_NE(msg.find("3"), std::string::npos);
+  EXPECT_NE(msg.find("10"), std::string::npos);
+  EXPECT_NE(msg.find("Pattern benchmarks"), std::string::npos);
+  EXPECT_NE(msg.find("completed"), std::string::npos);
+
+  // Verify the loop separator is present
+  EXPECT_NE(msg.find("3/10"), std::string::npos);
 }
 
 TEST_F(MessagesFormattingTest, MsgTlbAnalysisPageWalkProgress) {

--- a/tests/test_pattern_benchmark.cpp
+++ b/tests/test_pattern_benchmark.cpp
@@ -19,9 +19,84 @@
 #include "core/config/config.h"
 #include "utils/benchmark.h"  // Declares system_info functions
 #include "core/config/constants.h"
+#include "test_config_helpers.h"
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
+
+namespace {
+
+BenchmarkConfig make_pattern_config(size_t buffer_size, int iterations, int num_threads = 1) {
+  BenchmarkConfig config;
+  config.buffer_size = buffer_size;
+  config.iterations = iterations;
+  initialize_system_info(config);
+  config.num_threads = num_threads;
+  return config;
+}
+
+::testing::AssertionResult run_pattern_benchmarks_checked(BenchmarkBuffers& buffers,
+                                                          const BenchmarkConfig& config,
+                                                          PatternResults& results) {
+  const int run_result = run_pattern_benchmarks(buffers, config, results);
+  if (run_result != EXIT_SUCCESS) {
+    return ::testing::AssertionFailure()
+           << "run_pattern_benchmarks(buffers, config, results) failed with code " << run_result;
+  }
+
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult run_pattern_benchmarks_with_fresh_buffers(BenchmarkConfig& config,
+                                                                      PatternResults& results) {
+  BenchmarkBuffers buffers;
+  const ::testing::AssertionResult alloc_init_result = allocate_and_initialize_buffers(config, buffers);
+  if (!alloc_init_result) {
+    return alloc_init_result;
+  }
+
+  return run_pattern_benchmarks_checked(buffers, config, results);
+}
+
+void expect_core_pattern_bandwidths_positive(const PatternResults& results) {
+  EXPECT_GT(results.forward_read_bw, 0.0);
+  EXPECT_GT(results.forward_write_bw, 0.0);
+  EXPECT_GT(results.forward_copy_bw, 0.0);
+
+  EXPECT_GT(results.reverse_read_bw, 0.0);
+  EXPECT_GT(results.reverse_write_bw, 0.0);
+  EXPECT_GT(results.reverse_copy_bw, 0.0);
+
+  EXPECT_GT(results.strided_64_read_bw, 0.0);
+  EXPECT_GT(results.strided_64_write_bw, 0.0);
+  EXPECT_GT(results.strided_64_copy_bw, 0.0);
+
+  EXPECT_GT(results.strided_4096_read_bw, 0.0);
+  EXPECT_GT(results.strided_4096_write_bw, 0.0);
+  EXPECT_GT(results.strided_4096_copy_bw, 0.0);
+
+  EXPECT_GT(results.strided_16384_read_bw, 0.0);
+  EXPECT_GT(results.strided_16384_write_bw, 0.0);
+  EXPECT_GT(results.strided_16384_copy_bw, 0.0);
+
+  EXPECT_GT(results.random_read_bw, 0.0);
+  EXPECT_GT(results.random_write_bw, 0.0);
+  EXPECT_GT(results.random_copy_bw, 0.0);
+}
+
+void expect_2mb_pattern_bandwidths_zero(const PatternResults& results) {
+  EXPECT_EQ(results.strided_2mb_read_bw, 0.0);
+  EXPECT_EQ(results.strided_2mb_write_bw, 0.0);
+  EXPECT_EQ(results.strided_2mb_copy_bw, 0.0);
+}
+
+void expect_2mb_pattern_bandwidths_positive(const PatternResults& results) {
+  EXPECT_GT(results.strided_2mb_read_bw, 0.0);
+  EXPECT_GT(results.strided_2mb_write_bw, 0.0);
+  EXPECT_GT(results.strided_2mb_copy_bw, 0.0);
+}
+
+}  // namespace
 
 // Test PatternResults default initialization
 TEST(PatternBenchmarkTest, PatternResultsDefaultValues) {
@@ -73,84 +148,20 @@ TEST(PatternBenchmarkTest, PatternResultsSetValues) {
 // It runs real pattern benchmarks which may be slower and can fail on slow systems or under load.
 // Use 'make test-integration' to run integration tests, or 'make test' for unit tests only.
 TEST(PatternBenchmarkTest, RunPatternBenchmarksMinimalIntegration) {
-  BenchmarkConfig config;
-  config.buffer_size = 512 * 1024;  // 512 KB - large enough for all patterns including strided 4096
-  config.iterations = 1;  // Single iteration for speed
-  config.num_threads = 1;  // Single thread
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  // Allocate buffers
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  // Initialize buffers
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
-  // Run pattern benchmarks
+  BenchmarkConfig config = make_pattern_config(512 * 1024, 1);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  
-  EXPECT_EQ(result, EXIT_SUCCESS);
-  
-  // Verify that results were populated (should be > 0 for valid benchmarks)
-  EXPECT_GT(results.forward_read_bw, 0.0);
-  EXPECT_GT(results.forward_write_bw, 0.0);
-  EXPECT_GT(results.forward_copy_bw, 0.0);
-  EXPECT_GT(results.reverse_read_bw, 0.0);
-  EXPECT_GT(results.reverse_write_bw, 0.0);
-  EXPECT_GT(results.reverse_copy_bw, 0.0);
-  EXPECT_GT(results.strided_64_read_bw, 0.0);
-  EXPECT_GT(results.strided_64_write_bw, 0.0);
-  EXPECT_GT(results.strided_64_copy_bw, 0.0);
-  EXPECT_GT(results.strided_4096_read_bw, 0.0);
-  EXPECT_GT(results.strided_4096_write_bw, 0.0);
-  EXPECT_GT(results.strided_4096_copy_bw, 0.0);
-  EXPECT_GT(results.strided_16384_read_bw, 0.0);
-  EXPECT_GT(results.strided_16384_write_bw, 0.0);
-  EXPECT_GT(results.strided_16384_copy_bw, 0.0);
-  EXPECT_EQ(results.strided_2mb_read_bw, 0.0);
-  EXPECT_EQ(results.strided_2mb_write_bw, 0.0);
-  EXPECT_EQ(results.strided_2mb_copy_bw, 0.0);
-  EXPECT_GT(results.random_read_bw, 0.0);
-  EXPECT_GT(results.random_write_bw, 0.0);
-  EXPECT_GT(results.random_copy_bw, 0.0);
+
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
+
+  expect_core_pattern_bandwidths_positive(results);
+  expect_2mb_pattern_bandwidths_zero(results);
 }
 
 // Test pattern benchmarks with multiple iterations
 TEST(PatternBenchmarkTest, RunPatternBenchmarksMultipleIterations) {
-  BenchmarkConfig config;
-  config.buffer_size = 128 * 1024;  // 128 KB
-  config.iterations = 3;  // Multiple iterations
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
+  BenchmarkConfig config = make_pattern_config(128 * 1024, 3);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  
-  EXPECT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
   
   // All results should be positive
   EXPECT_GT(results.forward_read_bw, 0.0);
@@ -159,29 +170,9 @@ TEST(PatternBenchmarkTest, RunPatternBenchmarksMultipleIterations) {
 
 // Test that forward pattern is baseline (typically fastest)
 TEST(PatternBenchmarkTest, ForwardPatternBaseline) {
-  BenchmarkConfig config;
-  config.buffer_size = 256 * 1024;  // 256 KB
-  config.iterations = 2;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
+  BenchmarkConfig config = make_pattern_config(256 * 1024, 2);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  ASSERT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
   
   // All patterns should produce valid results
   EXPECT_GT(results.forward_read_bw, 0.0);
@@ -194,49 +185,12 @@ TEST(PatternBenchmarkTest, ForwardPatternBaseline) {
 
 // Test pattern benchmarks with different buffer sizes
 TEST(PatternBenchmarkTest, RunPatternBenchmarksDifferentSizes) {
-  BenchmarkConfig config1, config2;
-  
-  config1.buffer_size = 64 * 1024;  // 64 KB
-  config1.iterations = 1;
-  config1.num_threads = 1;
-  
-  config2.buffer_size = 512 * 1024;  // 512 KB
-  config2.iterations = 1;
-  config2.num_threads = 1;
-  
-  // Initialize system info for both
-  std::string cpu_name = get_processor_name();
-  int perf_cores = get_performance_cores();
-  int eff_cores = get_efficiency_cores();
-  int num_threads = get_total_logical_cores();
-  size_t l1_cache_size = get_l1_cache_size();
-  size_t l2_cache_size = get_l2_cache_size();
-  
-  config1.cpu_name = config2.cpu_name = cpu_name;
-  config1.perf_cores = config2.perf_cores = perf_cores;
-  config1.eff_cores = config2.eff_cores = eff_cores;
-  config1.num_threads = config2.num_threads = num_threads;
-  config1.l1_cache_size = config2.l1_cache_size = l1_cache_size;
-  config1.l2_cache_size = config2.l2_cache_size = l2_cache_size;
-  
-  BenchmarkBuffers buffers1, buffers2;
-  
-  int alloc_result1 = allocate_all_buffers(config1, buffers1);
-  ASSERT_EQ(alloc_result1, EXIT_SUCCESS);
-  int alloc_result2 = allocate_all_buffers(config2, buffers2);
-  ASSERT_EQ(alloc_result2, EXIT_SUCCESS);
-  
-  int init_result1 = initialize_all_buffers(buffers1, config1);
-  ASSERT_EQ(init_result1, EXIT_SUCCESS);
-  int init_result2 = initialize_all_buffers(buffers2, config2);
-  ASSERT_EQ(init_result2, EXIT_SUCCESS);
-  
+  BenchmarkConfig config1 = make_pattern_config(64 * 1024, 1);
+  BenchmarkConfig config2 = make_pattern_config(512 * 1024, 1);
+
   PatternResults results1, results2;
-  int result1 = run_pattern_benchmarks(buffers1, config1, results1);
-  int result2 = run_pattern_benchmarks(buffers2, config2, results2);
-  
-  EXPECT_EQ(result1, EXIT_SUCCESS);
-  EXPECT_EQ(result2, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config1, results1));
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config2, results2));
   
   // Both should produce valid results
   EXPECT_GT(results1.forward_read_bw, 0.0);
@@ -247,30 +201,9 @@ TEST(PatternBenchmarkTest, RunPatternBenchmarksDifferentSizes) {
 // This tests that random pattern benchmarks complete successfully, which implies
 // random indices were generated within valid bounds
 TEST(PatternBenchmarkTest, RandomIndicesGeneration) {
-  BenchmarkConfig config;
-  config.buffer_size = 1024 * 1024;  // 1 MB - enough for random pattern
-  config.iterations = 1;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
+  BenchmarkConfig config = make_pattern_config(1024 * 1024, 1);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  
-  EXPECT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
   
   // Random pattern should complete successfully, implying indices were valid
   EXPECT_GT(results.random_read_bw, 0.0);
@@ -286,31 +219,9 @@ TEST(PatternBenchmarkTest, RandomIndicesGeneration) {
 
 // Test pattern benchmarks with very small buffer (edge case)
 TEST(PatternBenchmarkTest, RunPatternBenchmarksSmallBuffer) {
-  BenchmarkConfig config;
-  config.buffer_size = 1024;  // 1 KB - very small
-  config.iterations = 1;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
+  BenchmarkConfig config = make_pattern_config(1024, 1);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  
-  // Should still succeed even with small buffer
-  EXPECT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
   
   // Results should be valid (may be small but should be > 0)
   EXPECT_GT(results.forward_read_bw, 0.0);
@@ -319,29 +230,9 @@ TEST(PatternBenchmarkTest, RunPatternBenchmarksSmallBuffer) {
 // Test that strided patterns use correct stride values
 // 64B stride should access cache lines, 4096B stride should access pages
 TEST(PatternBenchmarkTest, StridedPatternStrides) {
-  BenchmarkConfig config;
-  config.buffer_size = 512 * 1024;  // 512 KB - large enough for strided 4096 pattern
-  config.iterations = 2;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
+  BenchmarkConfig config = make_pattern_config(512 * 1024, 2);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  ASSERT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
   
   // Both strided patterns should complete successfully
   EXPECT_GT(results.strided_64_read_bw, 0.0);
@@ -357,132 +248,40 @@ TEST(PatternBenchmarkTest, StridedPatternStrides) {
 
 // Test large-page stride variants with a larger buffer
 TEST(PatternBenchmarkTest, StridedLargePagePatterns) {
-  BenchmarkConfig config;
-  config.buffer_size = 8 * 1024 * 1024;  // 8 MB - large enough for 2MB stride
-  config.iterations = 1;
-  config.num_threads = 1;
-
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  BenchmarkConfig config = make_pattern_config(8 * 1024 * 1024, 1);
 
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  ASSERT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
 
   EXPECT_GT(results.strided_16384_read_bw, 0.0);
   EXPECT_GT(results.strided_16384_write_bw, 0.0);
   EXPECT_GT(results.strided_16384_copy_bw, 0.0);
 
-  EXPECT_GT(results.strided_2mb_read_bw, 0.0);
-  EXPECT_GT(results.strided_2mb_write_bw, 0.0);
-  EXPECT_GT(results.strided_2mb_copy_bw, 0.0);
+  expect_2mb_pattern_bandwidths_positive(results);
 }
 
 // Test that all pattern types produce results
 TEST(PatternBenchmarkTest, AllPatternTypesComplete) {
-  BenchmarkConfig config;
-  config.buffer_size = 512 * 1024;  // 512 KB - large enough for all patterns including strided 4096
-  config.iterations = 1;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
-  
+  BenchmarkConfig config = make_pattern_config(512 * 1024, 1);
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  ASSERT_EQ(result, EXIT_SUCCESS);
-  
-  // Verify all pattern types have results
-  // Forward patterns
-  EXPECT_GT(results.forward_read_bw, 0.0);
-  EXPECT_GT(results.forward_write_bw, 0.0);
-  EXPECT_GT(results.forward_copy_bw, 0.0);
-  
-  // Reverse patterns
-  EXPECT_GT(results.reverse_read_bw, 0.0);
-  EXPECT_GT(results.reverse_write_bw, 0.0);
-  EXPECT_GT(results.reverse_copy_bw, 0.0);
-  
-  // Strided 64B patterns
-  EXPECT_GT(results.strided_64_read_bw, 0.0);
-  EXPECT_GT(results.strided_64_write_bw, 0.0);
-  EXPECT_GT(results.strided_64_copy_bw, 0.0);
-  
-  // Strided 4096B patterns
-  EXPECT_GT(results.strided_4096_read_bw, 0.0);
-  EXPECT_GT(results.strided_4096_write_bw, 0.0);
-  EXPECT_GT(results.strided_4096_copy_bw, 0.0);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
 
-  // Strided 16384B patterns
-  EXPECT_GT(results.strided_16384_read_bw, 0.0);
-  EXPECT_GT(results.strided_16384_write_bw, 0.0);
-  EXPECT_GT(results.strided_16384_copy_bw, 0.0);
-
-  // Strided 2MB patterns are skipped for 512KB buffer
-  EXPECT_EQ(results.strided_2mb_read_bw, 0.0);
-  EXPECT_EQ(results.strided_2mb_write_bw, 0.0);
-  EXPECT_EQ(results.strided_2mb_copy_bw, 0.0);
-  
-  // Random patterns
-  EXPECT_GT(results.random_read_bw, 0.0);
-  EXPECT_GT(results.random_write_bw, 0.0);
-  EXPECT_GT(results.random_copy_bw, 0.0);
+  expect_core_pattern_bandwidths_positive(results);
+  expect_2mb_pattern_bandwidths_zero(results);
 }
 
 // Test that pattern results are consistent across multiple runs
 // (Results may vary but should be in reasonable range)
 TEST(PatternBenchmarkTest, PatternResultsConsistency) {
-  BenchmarkConfig config;
-  config.buffer_size = 256 * 1024;  // 256 KB
-  config.iterations = 2;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  BenchmarkConfig config = make_pattern_config(256 * 1024, 2);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results1, results2;
-  
-  int result1 = run_pattern_benchmarks(buffers, config, results1);
-  ASSERT_EQ(result1, EXIT_SUCCESS);
-  
-  int result2 = run_pattern_benchmarks(buffers, config, results2);
-  ASSERT_EQ(result2, EXIT_SUCCESS);
+
+  ASSERT_TRUE(run_pattern_benchmarks_checked(buffers, config, results1));
+  ASSERT_TRUE(run_pattern_benchmarks_checked(buffers, config, results2));
   
   // Both runs should produce valid results
   EXPECT_GT(results1.forward_read_bw, 0.0);
@@ -497,32 +296,16 @@ TEST(PatternBenchmarkTest, PatternResultsConsistency) {
 
 // Test that copy operations use both source and destination buffers
 TEST(PatternBenchmarkTest, CopyOperationsUseBothBuffers) {
-  BenchmarkConfig config;
-  config.buffer_size = 512 * 1024;  // 512 KB - large enough for all patterns including strided 4096
-  config.iterations = 1;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  BenchmarkConfig config = make_pattern_config(512 * 1024, 1);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   // Verify buffers are different
   EXPECT_NE(buffers.src_buffer(), buffers.dst_buffer());
   
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  ASSERT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_checked(buffers, config, results));
   
   // Copy operations should complete successfully
   EXPECT_GT(results.forward_copy_bw, 0.0);
@@ -538,32 +321,10 @@ TEST(PatternBenchmarkTest, CopyOperationsUseBothBuffers) {
 TEST(PatternBenchmarkTest, StridedPatternSkippedWhenBufferTooSmall) {
   using namespace Constants;
   
-  BenchmarkConfig config;
-  // Use buffer size smaller than PATTERN_STRIDE_PAGE (4096B)
-  config.buffer_size = PATTERN_STRIDE_PAGE - 1;  // 4095 bytes - smaller than page stride
-  config.iterations = 1;
-  config.num_threads = 1;
-  
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
-  
-  BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  BenchmarkConfig config = make_pattern_config(PATTERN_STRIDE_PAGE - 1, 1);
   
   PatternResults results;
-  int result = run_pattern_benchmarks(buffers, config, results);
-  
-  // Should succeed (pattern skipped, not an error)
-  EXPECT_EQ(result, EXIT_SUCCESS);
+  ASSERT_TRUE(run_pattern_benchmarks_with_fresh_buffers(config, results));
   
   // Strided 4096B should be skipped (buffer too small)
   // When skipped, bandwidth remains 0.0
@@ -581,5 +342,3 @@ TEST(PatternBenchmarkTest, StridedPatternSkippedWhenBufferTooSmall) {
   // The important thing is that the test completes successfully
   SUCCEED();
 }
-
-

--- a/tests/test_pattern_validation.cpp
+++ b/tests/test_pattern_validation.cpp
@@ -19,6 +19,7 @@
 #include "core/memory/buffer_manager.h"
 #include "core/config/config.h"
 #include "utils/benchmark.h"
+#include "test_config_helpers.h"
 #include <iostream>
 #include <cstdlib>
 
@@ -37,20 +38,10 @@ TEST(PatternValidationTest, ValidateStrideBufferSmallerThanStride) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -78,20 +69,10 @@ TEST(PatternValidationTest, ValidateStrideBufferEqualToStride) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -116,20 +97,10 @@ TEST(PatternValidationTest, BufferSizeProgressionLessThanMin) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -151,20 +122,10 @@ TEST(PatternValidationTest, BufferSizeProgressionEqualToMin) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -186,20 +147,10 @@ TEST(PatternValidationTest, BufferSizeProgressionLessThanCacheLine) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -224,20 +175,10 @@ TEST(PatternValidationTest, BufferSizeProgressionEqualToCacheLine) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -262,20 +203,10 @@ TEST(PatternValidationTest, BufferSizeProgressionJustLargerThanCacheLine) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -296,20 +227,10 @@ TEST(PatternValidationTest, BufferSizeProgressionLessThanPage) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -330,20 +251,10 @@ TEST(PatternValidationTest, BufferSizeProgressionEqualToPage) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);
@@ -361,20 +272,10 @@ TEST(PatternValidationTest, BufferSizeProgressionJustLargerThanPage) {
   config.iterations = 1;
   config.num_threads = 1;
   
-  // Initialize system info
-  config.cpu_name = get_processor_name();
-  config.perf_cores = get_performance_cores();
-  config.eff_cores = get_efficiency_cores();
-  config.num_threads = get_total_logical_cores();
-  config.l1_cache_size = get_l1_cache_size();
-  config.l2_cache_size = get_l2_cache_size();
+  initialize_system_info(config);
   
   BenchmarkBuffers buffers;
-  int alloc_result = allocate_all_buffers(config, buffers);
-  ASSERT_EQ(alloc_result, EXIT_SUCCESS);
-  
-  int init_result = initialize_all_buffers(buffers, config);
-  ASSERT_EQ(init_result, EXIT_SUCCESS);
+  ASSERT_TRUE(allocate_and_initialize_buffers(config, buffers));
   
   PatternResults results;
   int result = run_pattern_benchmarks(buffers, config, results);

--- a/tests/test_statistics.cpp
+++ b/tests/test_statistics.cpp
@@ -30,48 +30,14 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include "test_statistics_helpers.h"
 #include "output/console/statistics.h"
 
 namespace {
 
-// Convenience: empty vector reused for all unused parameters.
-const std::vector<double> kE{};
-
-// ---------------------------------------------------------------------------
-// Call print_statistics() exercising only the bandwidth path (read_bw driven).
-// loop_count=2 bypasses the "loop_count <= 1" early-exit guard.
-// ---------------------------------------------------------------------------
-std::string capture_bw(const std::vector<double>& v) {
-  testing::internal::CaptureStdout();
-  print_statistics(
-      2, v, v, v,
-      kE, kE, kE, kE, kE, kE, kE, kE,
-      kE, kE, kE, kE,
-      false,
-      kE, kE, kE, kE,
-      kE, kE, kE, kE,
-      false, false);
-  return testing::internal::GetCapturedStdout();
-}
-
-// ---------------------------------------------------------------------------
-// Call print_statistics() exercising only the main-memory latency path.
-// only_latency=true suppresses bandwidth sections.
-// ---------------------------------------------------------------------------
-std::string capture_lat(const std::vector<double>& v) {
-  testing::internal::CaptureStdout();
-  print_statistics(
-      2,
-      kE, kE, kE,
-      kE, kE, kE, kE, kE, kE, kE, kE,
-      v,
-      kE, kE, kE,
-      false,
-      kE, kE, kE, kE,
-      kE, kE, kE, kE,
-      false, true);
-  return testing::internal::GetCapturedStdout();
-}
+const std::vector<double>& kE = test_statistics_helpers::empty_values();
+using test_statistics_helpers::capture_bw;
+using test_statistics_helpers::capture_lat;
 
 // ---------------------------------------------------------------------------
 // Parse the first floating-point number that follows the given label string.

--- a/tests/test_statistics_helpers.h
+++ b/tests/test_statistics_helpers.h
@@ -1,0 +1,123 @@
+#ifndef TEST_STATISTICS_HELPERS_H
+#define TEST_STATISTICS_HELPERS_H
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "output/console/statistics.h"
+
+namespace test_statistics_helpers {
+
+inline const std::vector<double>& empty_values() {
+  static const std::vector<double> k_empty_values;
+  return k_empty_values;
+}
+
+inline std::string capture_bw(const std::vector<double>& values) {
+  const std::vector<double>& empty = empty_values();
+  testing::internal::CaptureStdout();
+  print_statistics(2,
+                   values,
+                   values,
+                   values,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   false,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   false,
+                   false);
+  return testing::internal::GetCapturedStdout();
+}
+
+inline std::string capture_lat(const std::vector<double>& values) {
+  const std::vector<double>& empty = empty_values();
+  testing::internal::CaptureStdout();
+  print_statistics(2,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   values,
+                   empty,
+                   empty,
+                   empty,
+                   false,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   false,
+                   true);
+  return testing::internal::GetCapturedStdout();
+}
+
+inline std::string capture_auto_tlb_breakdown(const std::vector<double>& all_main_mem_latency,
+                                              const std::vector<double>& all_tlb_hit_latency,
+                                              const std::vector<double>& all_tlb_miss_latency,
+                                              const std::vector<double>& all_page_walk_penalty,
+                                              int loop_count = 2) {
+  const std::vector<double>& empty = empty_values();
+  testing::internal::CaptureStdout();
+  print_statistics(loop_count,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   all_main_mem_latency,
+                   all_tlb_hit_latency,
+                   all_tlb_miss_latency,
+                   all_page_walk_penalty,
+                   false,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   empty,
+                   false,
+                   true);
+  return testing::internal::GetCapturedStdout();
+}
+
+}  // namespace test_statistics_helpers
+
+#endif  // TEST_STATISTICS_HELPERS_H


### PR DESCRIPTION
This is more of a code clean up -version update, no changes in benchmarks.

## [0.53.9] - 2026-03-18

### Changed
  - **Centralized user-facing message strings**: Moved three remaining hardcoded user-facing strings to the Messages system:
    - Timer creation failure error (`main.cpp:95`) now uses `Messages::error_timer_creation_failed()`
    - JSON output success message (`file_writer.cpp:143`) now uses `Messages::msg_results_saved_to()`
    - Pattern benchmark loop progress (`pattern_statistics_manager.cpp:134`) now uses `Messages::msg_pattern_benchmark_loop_completed()`
  - **Test coverage for new message functions**: Added test cases for all three new message functions in `tests/test_messages.cpp`.
  - **DRY cleanup across benchmarks, warmup, and tests**: Extracted shared helpers to remove duplicated latency, warmup, pattern, and test setup code.