### PR TITLE
Version 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.0] - 2026-03-19
+
+Changes in benchmark ASM kernels.
+From this version onwards bandwidth results are not compatible against older(<0.54.0) version results.
+Latency kernels unchanged.
+
+### Changed
+  - Main change: split pattern ASM kernels into separate files for each case (main-memory, cache, forward, reverse, strided, random).
+  - Some kernels currently behave the same, but they are intentionally kept separate to make future tuning easier.
+  - Tuned cache ASM kernels with pointer+remaining loop state and bit-test based tail handling.
+  - Pattern strided benchmarks now scale effective iterations so each stride variant targets at least `256 MB` of touched data (for more stable results on small buffers).
+  - Added `PATTERN_STRIDED_MIN_TOUCHED_BYTES` constant (`256 * 1024 * 1024`) for strided pattern iteration scaling.
+  - Simplified and improved inline comments in cache ASM kernels:
+    - `src/asm/memory_write_cache.s`
+    - `src/asm/memory_read_cache.s`
+    - `src/asm/memory_copy_cache.s`
+  - Added clearer ABI/register-preservation notes, tail-bit (`tbz`) mapping notes, and short control-flow maps for easier future tuning.
+
 ## [0.53.9] - 2026-03-18
 
 ### Changed

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -507,7 +507,7 @@ For noisy systems, prioritize median and P95/P99 rather than single fastest/slow
   "main_memory": { ... },
   "cache": { ... },
   "timestamp": "2026-03-09T14:57:56Z",
-  "version": "0.53.8"
+  "version": "0.54.0"
 }
 ```
 
@@ -521,7 +521,7 @@ Note: The `configuration` block includes fields such as `latency_chain_mode` (th
   "execution_time_sec": 705.6,
   "patterns": { ... },
   "timestamp": "2026-03-09T15:10:01Z",
-  "version": "0.53.8"
+  "version": "0.54.0"
 }
 ```
 
@@ -851,4 +851,4 @@ memory_benchmark -h
 
 ---
 
-**Last Updated**: 2026-03-15
+**Last Updated**: 2026-03-19

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,12 @@ ALL_CPP_SRCS = $(CPP_SRCS_ROOT) $(CPP_SRCS_SRC_FULL) $(CPP_SRCS_BENCHMARK_FULL) 
 
 # Assembly source files (in src/asm)
 ASM_SRCS = src/asm/memory_copy.s src/asm/memory_read.s src/asm/memory_write.s src/asm/memory_latency.s \
+            src/asm/memory_read_cache.s src/asm/memory_write_cache.s src/asm/memory_copy_cache.s \
             src/asm/memory_read_reverse.s src/asm/memory_write_reverse.s src/asm/memory_copy_reverse.s \
             src/asm/memory_read_strided.s src/asm/memory_write_strided.s src/asm/memory_copy_strided.s \
+            src/asm/memory_read_strided_64.s src/asm/memory_read_strided_4096.s src/asm/memory_read_strided_16384.s src/asm/memory_read_strided_2mb.s \
+            src/asm/memory_write_strided_64.s src/asm/memory_write_strided_4096.s src/asm/memory_write_strided_16384.s src/asm/memory_write_strided_2mb.s \
+            src/asm/memory_copy_strided_64.s src/asm/memory_copy_strided_4096.s src/asm/memory_copy_strided_16384.s src/asm/memory_copy_strided_2mb.s \
             src/asm/memory_read_random.s src/asm/memory_write_random.s src/asm/memory_copy_random.s \
             src/asm/core_to_core_latency.s
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Project Structure — membenchmark
 
-**Version:** 0.53.9
+**Version:** 0.54.0
 **Platform:** ARM64 / AArch64 (Apple Silicon macOS)
 **License:** GNU General Public License v3.0
 
@@ -73,18 +73,33 @@ Hand-written AArch64 assembly implementing the hot inner loops that must not be 
 | File | Operation |
 |---|---|
 | `asm_functions.h` | `extern "C"` declarations for all assembly functions |
-| `memory_copy.s` | Sequential forward memory copy |
+| `memory_copy.s` | Sequential forward memory copy (main-memory, non-temporal stores) |
+| `memory_copy_cache.s` | Sequential forward memory copy (cache-focused) |
 | `memory_copy_random.s` | Random-order memory copy |
 | `memory_copy_reverse.s` | Reverse-order memory copy |
-| `memory_copy_strided.s` | Strided memory copy |
-| `memory_read.s` | Sequential forward memory read |
+| `memory_copy_strided.s` | Strided memory copy (generic stride parameter) |
+| `memory_copy_strided_64.s` | Strided memory copy — 64-byte stride |
+| `memory_copy_strided_4096.s` | Strided memory copy — 4096-byte stride |
+| `memory_copy_strided_16384.s` | Strided memory copy — 16384-byte stride |
+| `memory_copy_strided_2mb.s` | Strided memory copy — 2 MB stride |
+| `memory_read.s` | Sequential forward memory read (main-memory) |
+| `memory_read_cache.s` | Sequential forward memory read (cache-focused) |
 | `memory_read_random.s` | Random-order memory read |
 | `memory_read_reverse.s` | Reverse-order memory read |
-| `memory_read_strided.s` | Strided memory read |
-| `memory_write.s` | Sequential forward memory write |
+| `memory_read_strided.s` | Strided memory read (generic stride parameter) |
+| `memory_read_strided_64.s` | Strided memory read — 64-byte stride |
+| `memory_read_strided_4096.s` | Strided memory read — 4096-byte stride |
+| `memory_read_strided_16384.s` | Strided memory read — 16384-byte stride |
+| `memory_read_strided_2mb.s` | Strided memory read — 2 MB stride |
+| `memory_write.s` | Sequential forward memory write (main-memory, non-temporal stores) |
+| `memory_write_cache.s` | Sequential forward memory write (cache-focused) |
 | `memory_write_random.s` | Random-order memory write |
 | `memory_write_reverse.s` | Reverse-order memory write |
-| `memory_write_strided.s` | Strided memory write |
+| `memory_write_strided.s` | Strided memory write (generic stride parameter) |
+| `memory_write_strided_64.s` | Strided memory write — 64-byte stride |
+| `memory_write_strided_4096.s` | Strided memory write — 4096-byte stride |
+| `memory_write_strided_16384.s` | Strided memory write — 16384-byte stride |
+| `memory_write_strided_2mb.s` | Strided memory write — 2 MB stride |
 | `memory_latency.s` | Pointer-chase latency measurement loop |
 | `core_to_core_latency.s` | Cache-line handoff ping-pong loop for core-to-core latency |
 
@@ -142,7 +157,7 @@ Platform-independent infrastructure: configuration, memory management, system in
 |---|---|
 | `config.h` | `BenchmarkConfig` structure; aggregates all run-time settings parsed from the command line |
 | `constants.h` | Named constants for memory limits, cache size bounds, stride values, buffer sizing factors, and latency access counts |
-| `version.h` | `SOFTVERSION` macro (semantic version string, currently `"0.53.8"`) |
+| `version.h` | `SOFTVERSION` macro (semantic version string, currently `"0.54.0"`) |
 | `argument_parser.cpp` | Parses `argv` into a `BenchmarkConfig`; implements all flag definitions |
 | `config_validator.cpp` | Validates the parsed configuration; emits errors for out-of-range or conflicting settings |
 | `buffer_calculator.cpp` | Derives buffer sizes for each cache/memory level from the validated configuration and detected system parameters |

--- a/TECHNICAL_SPECIFICATION.md
+++ b/TECHNICAL_SPECIFICATION.md
@@ -2,7 +2,7 @@
 
 ## 1. Scope and Status
 
-This document specifies the current implementation in this repository (version series `0.53.x`) for `memory_benchmark` on macOS Apple Silicon.
+This document specifies the current implementation in this repository (version series `0.54.x`) for `memory_benchmark` on macOS Apple Silicon.
 
 It is intentionally implementation-driven and reflects real behavior in code paths under `main.cpp`, `src/core`, `src/benchmark`, `src/pattern_benchmark`, `src/output`, and `src/asm`.
 
@@ -317,8 +317,10 @@ Implementation notes:
 
 Assembly entrypoints are declared in `src/asm/asm_functions.h` and used by benchmark/warmup code:
 
-- Main kernels: read, write, copy, latency chase.
-- Pattern kernels: reverse, strided, random variants.
+- Main-memory kernels: read, write, copy (non-temporal stores).
+- Cache kernels: read, write, copy (cache-focused variants).
+- Latency kernel: pointer-chase loop.
+- Pattern kernels: reverse (read/write/copy), strided generic (read/write/copy), strided fixed-stride variants (64B, 4096B, 16384B, 2MB — each as read/write/copy), random (read/write/copy).
 - Core-to-core kernels: initiator and responder round-trip loops.
 
 Design intent:

--- a/src/asm/asm_functions.h
+++ b/src/asm/asm_functions.h
@@ -43,6 +43,14 @@ extern "C" {
      * @param byteCount Number of bytes to copy
      */
     void memory_copy_loop_asm(void* dst, const void* src, size_t byteCount);
+
+    /**
+     * @brief Optimized cache-focused memory copy loop (assembly)
+     * @param dst Destination buffer pointer
+     * @param src Source buffer pointer
+     * @param byteCount Number of bytes to copy
+     */
+    void memory_copy_cache_loop_asm(void* dst, const void* src, size_t byteCount);
     
     /**
      * @brief Optimized memory read loop (assembly)
@@ -51,6 +59,14 @@ extern "C" {
      * @return Checksum of read data
      */
     uint64_t memory_read_loop_asm(const void* src, size_t byteCount);
+
+    /**
+     * @brief Optimized cache-focused memory read loop (assembly)
+     * @param src Source buffer pointer
+     * @param byteCount Number of bytes to read
+     * @return Checksum of read data
+     */
+    uint64_t memory_read_cache_loop_asm(const void* src, size_t byteCount);
     
     /**
      * @brief Optimized memory write loop (assembly)
@@ -58,6 +74,13 @@ extern "C" {
      * @param byteCount Number of bytes to write
      */
     void memory_write_loop_asm(void* dst, size_t byteCount);
+
+    /**
+     * @brief Optimized cache-focused memory write loop (assembly)
+     * @param dst Destination buffer pointer
+     * @param byteCount Number of bytes to write
+     */
+    void memory_write_cache_loop_asm(void* dst, size_t byteCount);
     
     /**
      * @brief Pointer chasing loop for latency measurement (assembly)
@@ -126,6 +149,42 @@ extern "C" {
      * @return Checksum of read data
      */
     uint64_t memory_read_strided_loop_asm(const void* src, size_t byteCount, size_t stride, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory read loop for 64-byte stride
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     * @return Checksum of read data
+     */
+    uint64_t memory_read_strided_64_loop_asm(const void* src, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory read loop for 4096-byte stride
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     * @return Checksum of read data
+     */
+    uint64_t memory_read_strided_4096_loop_asm(const void* src, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory read loop for 16384-byte stride
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     * @return Checksum of read data
+     */
+    uint64_t memory_read_strided_16384_loop_asm(const void* src, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory read loop for 2MB stride
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     * @return Checksum of read data
+     */
+    uint64_t memory_read_strided_2mb_loop_asm(const void* src, size_t byteCount, size_t num_iterations);
     
     /**
      * @brief Optimized strided memory write loop (assembly)
@@ -135,6 +194,38 @@ extern "C" {
      * @param num_iterations Number of strided accesses to perform
      */
     void memory_write_strided_loop_asm(void* dst, size_t byteCount, size_t stride, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory write loop for 64-byte stride
+     * @param dst Destination buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_write_strided_64_loop_asm(void* dst, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory write loop for 4096-byte stride
+     * @param dst Destination buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_write_strided_4096_loop_asm(void* dst, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory write loop for 16384-byte stride
+     * @param dst Destination buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_write_strided_16384_loop_asm(void* dst, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory write loop for 2MB stride
+     * @param dst Destination buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_write_strided_2mb_loop_asm(void* dst, size_t byteCount, size_t num_iterations);
     
     /**
      * @brief Optimized strided memory copy loop (assembly)
@@ -145,6 +236,42 @@ extern "C" {
      * @param num_iterations Number of strided accesses to perform
      */
     void memory_copy_strided_loop_asm(void* dst, const void* src, size_t byteCount, size_t stride, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory copy loop for 64-byte stride
+     * @param dst Destination buffer pointer
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_copy_strided_64_loop_asm(void* dst, const void* src, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory copy loop for 4096-byte stride
+     * @param dst Destination buffer pointer
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_copy_strided_4096_loop_asm(void* dst, const void* src, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory copy loop for 16384-byte stride
+     * @param dst Destination buffer pointer
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_copy_strided_16384_loop_asm(void* dst, const void* src, size_t byteCount, size_t num_iterations);
+
+    /**
+     * @brief Optimized strided memory copy loop for 2MB stride
+     * @param dst Destination buffer pointer
+     * @param src Source buffer pointer
+     * @param byteCount Total buffer size in bytes (for modulo wrapping)
+     * @param num_iterations Number of strided accesses to perform
+     */
+    void memory_copy_strided_2mb_loop_asm(void* dst, const void* src, size_t byteCount, size_t num_iterations);
     
     // Random access
     /**

--- a/src/asm/memory_copy_cache.s
+++ b/src/asm/memory_copy_cache.s
@@ -31,69 +31,72 @@
 //   x3-x8, q0-q7, q16-q31 (caller-saved only)
 // Assumptions / Guarantees:
 //   * Undefined behavior if regions overlap (not a memmove replacement).
+// Implementation Notes:
+//   * Uses pointer+remaining loop state (x6/x7/x5) to reduce loop-control overhead.
+//   * Processes 512B per iteration with 16 load/store pairs.
+//   * Main body interleaves load/store pairs to keep copy pipeline busy.
+//   * Tail uses bit-tested chunk ladder plus 16/8/4/2/1 scalar finish.
 // -----------------------------------------------------------------------------
 
 .global _memory_copy_cache_loop_asm
 .align 4
 _memory_copy_cache_loop_asm:
-    mov x3, xzr
-    mov x4, #512
+    // x6 = current src, x7 = current dst, x5 = remaining bytes.
+    mov x6, x1
+    mov x7, x0
+    mov x5, x2
 
-copy_cache_loop_start_nt512:
-    subs x5, x2, x3
-    cmp x5, x4
+copy_cache_loop_start_nt512:  // Main 512B loop
+    // If <512B remain, switch to tail handling.
+    cmp x5, #512
     b.lo copy_cache_loop_cleanup
 
-    add x6, x1, x3
-    add x7, x0, x3
-
+    // Interleaved load/store pairs across one 512B block.
     ldp q0,  q1,  [x6, #0]
+    stp q0,  q1,  [x7, #0]
     ldp q2,  q3,  [x6, #32]
+    stp q2,  q3,  [x7, #32]
     ldp q4,  q5,  [x6, #64]
+    stp q4,  q5,  [x7, #64]
     ldp q6,  q7,  [x6, #96]
+    stp q6,  q7,  [x7, #96]
     ldp q16, q17, [x6, #128]
+    stp q16, q17, [x7, #128]
     ldp q18, q19, [x6, #160]
+    stp q18, q19, [x7, #160]
     ldp q20, q21, [x6, #192]
+    stp q20, q21, [x7, #192]
     ldp q22, q23, [x6, #224]
-    stnp q0,  q1,  [x7, #0]
-    stnp q2,  q3,  [x7, #32]
-    stnp q4,  q5,  [x7, #64]
-    stnp q6,  q7,  [x7, #96]
-    stnp q16, q17, [x7, #128]
-    stnp q18, q19, [x7, #160]
-    stnp q20, q21, [x7, #192]
-    stnp q22, q23, [x7, #224]
-
+    stp q22, q23, [x7, #224]
     ldp q24, q25, [x6, #256]
+    stp q24, q25, [x7, #256]
     ldp q26, q27, [x6, #288]
+    stp q26, q27, [x7, #288]
     ldp q28, q29, [x6, #320]
+    stp q28, q29, [x7, #320]
     ldp q30, q31, [x6, #352]
+    stp q30, q31, [x7, #352]
     ldp q0,  q1,  [x6, #384]
+    stp q0,  q1,  [x7, #384]
     ldp q2,  q3,  [x6, #416]
+    stp q2,  q3,  [x7, #416]
     ldp q4,  q5,  [x6, #448]
+    stp q4,  q5,  [x7, #448]
     ldp q6,  q7,  [x6, #480]
-    stnp q24, q25, [x7, #256]
-    stnp q26, q27, [x7, #288]
-    stnp q28, q29, [x7, #320]
-    stnp q30, q31, [x7, #352]
-    stnp q0,  q1,  [x7, #384]
-    stnp q2,  q3,  [x7, #416]
-    stnp q4,  q5,  [x7, #448]
-    stnp q6,  q7,  [x7, #480]
+    stp q6,  q7,  [x7, #480]
 
-    add x3, x3, x4
+    // Advance both pointers and remaining-byte counter.
+    add x6, x6, #512
+    add x7, x7, #512
+    sub x5, x5, #512
     b copy_cache_loop_start_nt512
 
-copy_cache_loop_cleanup:
-    cmp x3, x2
-    b.hs copy_cache_loop_end
+copy_cache_loop_cleanup:      // Tail handling when <512B remain
+    cbz x5, copy_cache_loop_end
 
-    subs x5, x2, x3
-    add x6, x1, x3
-    add x7, x0, x3
-
-    cmp x5, #256
-    b.lo copy_cache_cleanup_128
+    // Tiered tail: test size bits for 256/128/64/32 before scalar ladder.
+    tbz x5, #8, copy_cache_cleanup_128
+    // 256B chunk
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     ldp q4, q5, [x6, #64]
@@ -102,59 +105,78 @@ copy_cache_loop_cleanup:
     ldp q18, q19, [x6, #160]
     ldp q20, q21, [x6, #192]
     ldp q22, q23, [x6, #224]
-    stnp q0, q1, [x7, #0]
-    stnp q2, q3, [x7, #32]
-    stnp q4, q5, [x7, #64]
-    stnp q6, q7, [x7, #96]
-    stnp q16, q17, [x7, #128]
-    stnp q18, q19, [x7, #160]
-    stnp q20, q21, [x7, #192]
-    stnp q22, q23, [x7, #224]
+    stp q0, q1, [x7, #0]
+    stp q2, q3, [x7, #32]
+    stp q4, q5, [x7, #64]
+    stp q6, q7, [x7, #96]
+    stp q16, q17, [x7, #128]
+    stp q18, q19, [x7, #160]
+    stp q20, q21, [x7, #192]
+    stp q22, q23, [x7, #224]
     add x6, x6, #256
     add x7, x7, #256
     sub x5, x5, #256
 
-copy_cache_cleanup_128:
-    cmp x5, #128
-    b.lo copy_cache_cleanup_64
+copy_cache_cleanup_128:       // Optional 128B chunk
+    tbz x5, #7, copy_cache_cleanup_64
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     ldp q4, q5, [x6, #64]
     ldp q6, q7, [x6, #96]
-    stnp q0, q1, [x7, #0]
-    stnp q2, q3, [x7, #32]
-    stnp q4, q5, [x7, #64]
-    stnp q6, q7, [x7, #96]
+    stp q0, q1, [x7, #0]
+    stp q2, q3, [x7, #32]
+    stp q4, q5, [x7, #64]
+    stp q6, q7, [x7, #96]
     add x6, x6, #128
     add x7, x7, #128
     sub x5, x5, #128
 
-copy_cache_cleanup_64:
-    cmp x5, #64
-    b.lo copy_cache_cleanup_32
+copy_cache_cleanup_64:        // Optional 64B chunk
+    tbz x5, #6, copy_cache_cleanup_32
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
-    stnp q0, q1, [x7, #0]
-    stnp q2, q3, [x7, #32]
+    stp q0, q1, [x7, #0]
+    stp q2, q3, [x7, #32]
     add x6, x6, #64
     add x7, x7, #64
     sub x5, x5, #64
 
-copy_cache_cleanup_32:
-    cmp x5, #32
-    b.lo copy_cache_cleanup_byte
+copy_cache_cleanup_32:        // Optional 32B chunk
+    tbz x5, #5, copy_cache_cleanup_16
     ldp q0, q1, [x6, #0]
-    stnp q0, q1, [x7, #0]
+    stp q0, q1, [x7, #0]
     add x6, x6, #32
     add x7, x7, #32
     sub x5, x5, #32
 
-copy_cache_cleanup_byte:
-    cbz x5, copy_cache_loop_end
-    ldrb w8, [x6], #1
-    strb w8, [x7], #1
-    subs x5, x5, #1
-    b.ne copy_cache_cleanup_byte
+copy_cache_cleanup_16:        // Optional 16B scalar copy
+    tbz x5, #4, copy_cache_cleanup_8
+    ldr q0, [x6], #16
+    str q0, [x7], #16
+    sub x5, x5, #16
 
-copy_cache_loop_end:
+copy_cache_cleanup_8:         // Optional 8B scalar copy
+    tbz x5, #3, copy_cache_cleanup_4
+    ldr x8, [x6], #8
+    str x8, [x7], #8
+    sub x5, x5, #8
+
+copy_cache_cleanup_4:         // Optional 4B scalar copy
+    tbz x5, #2, copy_cache_cleanup_2
+    ldr w8, [x6], #4
+    str w8, [x7], #4
+    sub x5, x5, #4
+
+copy_cache_cleanup_2:         // Optional 2B scalar copy
+    tbz x5, #1, copy_cache_cleanup_1
+    ldrh w8, [x6], #2
+    strh w8, [x7], #2
+    sub x5, x5, #2
+
+copy_cache_cleanup_1:         // Optional final 1B copy
+    tbz x5, #0, copy_cache_loop_end
+    ldrb w8, [x6]
+    strb w8, [x7]
+
+copy_cache_loop_end:          // Return to caller
     ret

--- a/src/asm/memory_copy_cache.s
+++ b/src/asm/memory_copy_cache.s
@@ -1,0 +1,160 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_copy_cache_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_copy_cache_loop_asm(void* dst, const void* src, size_t byteCount);
+// Purpose:
+//   Copy 'byteCount' bytes from 'src' to 'dst' for cache-bandwidth paths (L1/L2/custom).
+//   This kernel is intentionally independent from main-memory copy kernel so cache
+//   tuning can evolve without coupling to DRAM path behavior.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = src (const void*)
+//   x2 = byteCount (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x3-x8, q0-q7, q16-q31 (caller-saved only)
+// Assumptions / Guarantees:
+//   * Undefined behavior if regions overlap (not a memmove replacement).
+// -----------------------------------------------------------------------------
+
+.global _memory_copy_cache_loop_asm
+.align 4
+_memory_copy_cache_loop_asm:
+    mov x3, xzr
+    mov x4, #512
+
+copy_cache_loop_start_nt512:
+    subs x5, x2, x3
+    cmp x5, x4
+    b.lo copy_cache_loop_cleanup
+
+    add x6, x1, x3
+    add x7, x0, x3
+
+    ldp q0,  q1,  [x6, #0]
+    ldp q2,  q3,  [x6, #32]
+    ldp q4,  q5,  [x6, #64]
+    ldp q6,  q7,  [x6, #96]
+    ldp q16, q17, [x6, #128]
+    ldp q18, q19, [x6, #160]
+    ldp q20, q21, [x6, #192]
+    ldp q22, q23, [x6, #224]
+    stnp q0,  q1,  [x7, #0]
+    stnp q2,  q3,  [x7, #32]
+    stnp q4,  q5,  [x7, #64]
+    stnp q6,  q7,  [x7, #96]
+    stnp q16, q17, [x7, #128]
+    stnp q18, q19, [x7, #160]
+    stnp q20, q21, [x7, #192]
+    stnp q22, q23, [x7, #224]
+
+    ldp q24, q25, [x6, #256]
+    ldp q26, q27, [x6, #288]
+    ldp q28, q29, [x6, #320]
+    ldp q30, q31, [x6, #352]
+    ldp q0,  q1,  [x6, #384]
+    ldp q2,  q3,  [x6, #416]
+    ldp q4,  q5,  [x6, #448]
+    ldp q6,  q7,  [x6, #480]
+    stnp q24, q25, [x7, #256]
+    stnp q26, q27, [x7, #288]
+    stnp q28, q29, [x7, #320]
+    stnp q30, q31, [x7, #352]
+    stnp q0,  q1,  [x7, #384]
+    stnp q2,  q3,  [x7, #416]
+    stnp q4,  q5,  [x7, #448]
+    stnp q6,  q7,  [x7, #480]
+
+    add x3, x3, x4
+    b copy_cache_loop_start_nt512
+
+copy_cache_loop_cleanup:
+    cmp x3, x2
+    b.hs copy_cache_loop_end
+
+    subs x5, x2, x3
+    add x6, x1, x3
+    add x7, x0, x3
+
+    cmp x5, #256
+    b.lo copy_cache_cleanup_128
+    ldp q0, q1, [x6, #0]
+    ldp q2, q3, [x6, #32]
+    ldp q4, q5, [x6, #64]
+    ldp q6, q7, [x6, #96]
+    ldp q16, q17, [x6, #128]
+    ldp q18, q19, [x6, #160]
+    ldp q20, q21, [x6, #192]
+    ldp q22, q23, [x6, #224]
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    stnp q4, q5, [x7, #64]
+    stnp q6, q7, [x7, #96]
+    stnp q16, q17, [x7, #128]
+    stnp q18, q19, [x7, #160]
+    stnp q20, q21, [x7, #192]
+    stnp q22, q23, [x7, #224]
+    add x6, x6, #256
+    add x7, x7, #256
+    sub x5, x5, #256
+
+copy_cache_cleanup_128:
+    cmp x5, #128
+    b.lo copy_cache_cleanup_64
+    ldp q0, q1, [x6, #0]
+    ldp q2, q3, [x6, #32]
+    ldp q4, q5, [x6, #64]
+    ldp q6, q7, [x6, #96]
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    stnp q4, q5, [x7, #64]
+    stnp q6, q7, [x7, #96]
+    add x6, x6, #128
+    add x7, x7, #128
+    sub x5, x5, #128
+
+copy_cache_cleanup_64:
+    cmp x5, #64
+    b.lo copy_cache_cleanup_32
+    ldp q0, q1, [x6, #0]
+    ldp q2, q3, [x6, #32]
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    add x6, x6, #64
+    add x7, x7, #64
+    sub x5, x5, #64
+
+copy_cache_cleanup_32:
+    cmp x5, #32
+    b.lo copy_cache_cleanup_byte
+    ldp q0, q1, [x6, #0]
+    stnp q0, q1, [x7, #0]
+    add x6, x6, #32
+    add x7, x7, #32
+    sub x5, x5, #32
+
+copy_cache_cleanup_byte:
+    cbz x5, copy_cache_loop_end
+    ldrb w8, [x6], #1
+    strb w8, [x7], #1
+    subs x5, x5, #1
+    b.ne copy_cache_cleanup_byte
+
+copy_cache_loop_end:
+    ret

--- a/src/asm/memory_copy_cache.s
+++ b/src/asm/memory_copy_cache.s
@@ -31,11 +31,16 @@
 //   x3-x8, q0-q7, q16-q31 (caller-saved only)
 // Assumptions / Guarantees:
 //   * Undefined behavior if regions overlap (not a memmove replacement).
+// ABI Notes:
+//   * AAPCS64 callee-saved registers are preserved (x19-x28, v8-v15 untouched).
+//   * Caller is expected to provide readable/writable ranges for full byteCount.
 // Implementation Notes:
 //   * Uses pointer+remaining loop state (x7/x6/x5) with 512B step size.
 //   * Processes 512B per iteration with 16 load/store pairs.
-//   * Uses STNP for cache-path store behavior.
+//   * Uses STNP for the cache-oriented store path used by this benchmark mode.
 //   * Tail path uses size-bit tiers (256/128/64/32/16/8/4/2/1).
+// Control-Flow Map:
+//   main 512B loop -> tiered tail (256/128/64/32) -> scalar tail -> return
 // -----------------------------------------------------------------------------
 
 .global _memory_copy_cache_loop_asm
@@ -94,6 +99,8 @@ copy_cache_loop_start_nt512:  // Main 512B loop
 copy_cache_loop_cleanup:      // Tail handling when <512B remain
     cbz x5, copy_cache_loop_end
 
+    // Tiered tail: bits in x5 encode optional chunks.
+    // bit8=256B, bit7=128B, bit6=64B, bit5=32B.
     // 256B chunk
     tbz x5, #8, copy_cache_cleanup_128
     ldp q0, q1, [x6, #0]

--- a/src/asm/memory_copy_cache.s
+++ b/src/asm/memory_copy_cache.s
@@ -32,71 +32,81 @@
 // Assumptions / Guarantees:
 //   * Undefined behavior if regions overlap (not a memmove replacement).
 // Implementation Notes:
-//   * Uses pointer+remaining loop state (x6/x7/x5) to reduce loop-control overhead.
+//   * Uses offset-based loop state (x3) with 512B step size.
 //   * Processes 512B per iteration with 16 load/store pairs.
-//   * Main body interleaves load/store pairs to keep copy pipeline busy.
-//   * Tail uses bit-tested chunk ladder plus 16/8/4/2/1 scalar finish.
+//   * Uses STNP for cache-path store behavior parity with prior baseline.
+//   * Tail path mirrors 256/128/64/32 tiers then byte cleanup.
 // -----------------------------------------------------------------------------
 
 .global _memory_copy_cache_loop_asm
 .align 4
 _memory_copy_cache_loop_asm:
-    // x6 = current src, x7 = current dst, x5 = remaining bytes.
-    mov x6, x1
-    mov x7, x0
-    mov x5, x2
+    // offset-based loop state (matches baseline cache-copy behavior)
+    mov x3, xzr               // offset = 0
+    mov x4, #512              // step = 512 bytes
 
 copy_cache_loop_start_nt512:  // Main 512B loop
-    // If <512B remain, switch to tail handling.
-    cmp x5, #512
+    // Loop invariants: x4=512B step, x0/x1 are base pointers.
+    // x3 tracks current offset and x5 tracks remaining bytes.
+    subs x5, x2, x3           // remaining = count - offset
+    cmp x5, x4                // remaining < 512?
     b.lo copy_cache_loop_cleanup
 
-    // Interleaved load/store pairs across one 512B block.
-    ldp q0,  q1,  [x6, #0]
-    stp q0,  q1,  [x7, #0]
-    ldp q2,  q3,  [x6, #32]
-    stp q2,  q3,  [x7, #32]
-    ldp q4,  q5,  [x6, #64]
-    stp q4,  q5,  [x7, #64]
-    ldp q6,  q7,  [x6, #96]
-    stp q6,  q7,  [x7, #96]
-    ldp q16, q17, [x6, #128]
-    stp q16, q17, [x7, #128]
-    ldp q18, q19, [x6, #160]
-    stp q18, q19, [x7, #160]
-    ldp q20, q21, [x6, #192]
-    stp q20, q21, [x7, #192]
-    ldp q22, q23, [x6, #224]
-    stp q22, q23, [x7, #224]
-    ldp q24, q25, [x6, #256]
-    stp q24, q25, [x7, #256]
-    ldp q26, q27, [x6, #288]
-    stp q26, q27, [x7, #288]
-    ldp q28, q29, [x6, #320]
-    stp q28, q29, [x7, #320]
-    ldp q30, q31, [x6, #352]
-    stp q30, q31, [x7, #352]
-    ldp q0,  q1,  [x6, #384]
-    stp q0,  q1,  [x7, #384]
-    ldp q2,  q3,  [x6, #416]
-    stp q2,  q3,  [x7, #416]
-    ldp q4,  q5,  [x6, #448]
-    stp q4,  q5,  [x7, #448]
-    ldp q6,  q7,  [x6, #480]
-    stp q6,  q7,  [x7, #480]
+    // Calculate current src/dst addresses.
+    add x6, x1, x3            // src + offset
+    add x7, x0, x3            // dst + offset
 
-    // Advance both pointers and remaining-byte counter.
-    add x6, x6, #512
-    add x7, x7, #512
-    sub x5, x5, #512
+    // First 256B: load then store as 8x pair operations.
+    ldp q0,  q1,  [x6, #0]
+    ldp q2,  q3,  [x6, #32]
+    ldp q4,  q5,  [x6, #64]
+    ldp q6,  q7,  [x6, #96]
+    ldp q16, q17, [x6, #128]
+    ldp q18, q19, [x6, #160]
+    ldp q20, q21, [x6, #192]
+    ldp q22, q23, [x6, #224]
+    stnp q0,  q1,  [x7, #0]
+    stnp q2,  q3,  [x7, #32]
+    stnp q4,  q5,  [x7, #64]
+    stnp q6,  q7,  [x7, #96]
+    stnp q16, q17, [x7, #128]
+    stnp q18, q19, [x7, #160]
+    stnp q20, q21, [x7, #192]
+    stnp q22, q23, [x7, #224]
+
+    // Second 256B: reuse registers, keep same memory pattern.
+    ldp q24, q25, [x6, #256]
+    ldp q26, q27, [x6, #288]
+    ldp q28, q29, [x6, #320]
+    ldp q30, q31, [x6, #352]
+    ldp q0,  q1,  [x6, #384]
+    ldp q2,  q3,  [x6, #416]
+    ldp q4,  q5,  [x6, #448]
+    ldp q6,  q7,  [x6, #480]
+    stnp q24, q25, [x7, #256]
+    stnp q26, q27, [x7, #288]
+    stnp q28, q29, [x7, #320]
+    stnp q30, q31, [x7, #352]
+    stnp q0,  q1,  [x7, #384]
+    stnp q2,  q3,  [x7, #416]
+    stnp q4,  q5,  [x7, #448]
+    stnp q6,  q7,  [x7, #480]
+
+    add x3, x3, x4            // offset += 512
     b copy_cache_loop_start_nt512
 
 copy_cache_loop_cleanup:      // Tail handling when <512B remain
-    cbz x5, copy_cache_loop_end
+    cmp x3, x2
+    b.hs copy_cache_loop_end
 
-    // Tiered tail: test size bits for 256/128/64/32 before scalar ladder.
-    tbz x5, #8, copy_cache_cleanup_128
+    // Recompute remaining and current pointers for tiered tail copy.
+    subs x5, x2, x3
+    add x6, x1, x3
+    add x7, x0, x3
+
     // 256B chunk
+    cmp x5, #256
+    b.lo copy_cache_cleanup_128
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     ldp q4, q5, [x6, #64]
@@ -105,78 +115,59 @@ copy_cache_loop_cleanup:      // Tail handling when <512B remain
     ldp q18, q19, [x6, #160]
     ldp q20, q21, [x6, #192]
     ldp q22, q23, [x6, #224]
-    stp q0, q1, [x7, #0]
-    stp q2, q3, [x7, #32]
-    stp q4, q5, [x7, #64]
-    stp q6, q7, [x7, #96]
-    stp q16, q17, [x7, #128]
-    stp q18, q19, [x7, #160]
-    stp q20, q21, [x7, #192]
-    stp q22, q23, [x7, #224]
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    stnp q4, q5, [x7, #64]
+    stnp q6, q7, [x7, #96]
+    stnp q16, q17, [x7, #128]
+    stnp q18, q19, [x7, #160]
+    stnp q20, q21, [x7, #192]
+    stnp q22, q23, [x7, #224]
     add x6, x6, #256
     add x7, x7, #256
     sub x5, x5, #256
 
 copy_cache_cleanup_128:       // Optional 128B chunk
-    tbz x5, #7, copy_cache_cleanup_64
+    cmp x5, #128
+    b.lo copy_cache_cleanup_64
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     ldp q4, q5, [x6, #64]
     ldp q6, q7, [x6, #96]
-    stp q0, q1, [x7, #0]
-    stp q2, q3, [x7, #32]
-    stp q4, q5, [x7, #64]
-    stp q6, q7, [x7, #96]
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    stnp q4, q5, [x7, #64]
+    stnp q6, q7, [x7, #96]
     add x6, x6, #128
     add x7, x7, #128
     sub x5, x5, #128
 
 copy_cache_cleanup_64:        // Optional 64B chunk
-    tbz x5, #6, copy_cache_cleanup_32
+    cmp x5, #64
+    b.lo copy_cache_cleanup_32
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
-    stp q0, q1, [x7, #0]
-    stp q2, q3, [x7, #32]
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
     add x6, x6, #64
     add x7, x7, #64
     sub x5, x5, #64
 
 copy_cache_cleanup_32:        // Optional 32B chunk
-    tbz x5, #5, copy_cache_cleanup_16
+    cmp x5, #32
+    b.lo copy_cache_cleanup_byte
     ldp q0, q1, [x6, #0]
-    stp q0, q1, [x7, #0]
+    stnp q0, q1, [x7, #0]
     add x6, x6, #32
     add x7, x7, #32
     sub x5, x5, #32
 
-copy_cache_cleanup_16:        // Optional 16B scalar copy
-    tbz x5, #4, copy_cache_cleanup_8
-    ldr q0, [x6], #16
-    str q0, [x7], #16
-    sub x5, x5, #16
-
-copy_cache_cleanup_8:         // Optional 8B scalar copy
-    tbz x5, #3, copy_cache_cleanup_4
-    ldr x8, [x6], #8
-    str x8, [x7], #8
-    sub x5, x5, #8
-
-copy_cache_cleanup_4:         // Optional 4B scalar copy
-    tbz x5, #2, copy_cache_cleanup_2
-    ldr w8, [x6], #4
-    str w8, [x7], #4
-    sub x5, x5, #4
-
-copy_cache_cleanup_2:         // Optional 2B scalar copy
-    tbz x5, #1, copy_cache_cleanup_1
-    ldrh w8, [x6], #2
-    strh w8, [x7], #2
-    sub x5, x5, #2
-
-copy_cache_cleanup_1:         // Optional final 1B copy
-    tbz x5, #0, copy_cache_loop_end
-    ldrb w8, [x6]
-    strb w8, [x7]
+copy_cache_cleanup_byte:      // Final byte tail (<32B)
+    cbz x5, copy_cache_loop_end
+    ldrb w8, [x6], #1
+    strb w8, [x7], #1
+    subs x5, x5, #1
+    b.ne copy_cache_cleanup_byte
 
 copy_cache_loop_end:          // Return to caller
     ret

--- a/src/asm/memory_copy_cache.s
+++ b/src/asm/memory_copy_cache.s
@@ -32,31 +32,25 @@
 // Assumptions / Guarantees:
 //   * Undefined behavior if regions overlap (not a memmove replacement).
 // Implementation Notes:
-//   * Uses offset-based loop state (x3) with 512B step size.
+//   * Uses pointer+remaining loop state (x7/x6/x5) with 512B step size.
 //   * Processes 512B per iteration with 16 load/store pairs.
-//   * Uses STNP for cache-path store behavior parity with prior baseline.
-//   * Tail path mirrors 256/128/64/32 tiers then byte cleanup.
+//   * Uses STNP for cache-path store behavior.
+//   * Tail path uses size-bit tiers (256/128/64/32/16/8/4/2/1).
 // -----------------------------------------------------------------------------
 
 .global _memory_copy_cache_loop_asm
 .align 4
 _memory_copy_cache_loop_asm:
-    // offset-based loop state (matches baseline cache-copy behavior)
-    mov x3, xzr               // offset = 0
-    mov x4, #512              // step = 512 bytes
+    // pointer+remaining loop state (lower loop-control overhead)
+    mov x7, x0                // dst ptr
+    mov x6, x1                // src ptr
+    mov x5, x2                // remaining bytes
 
 copy_cache_loop_start_nt512:  // Main 512B loop
-    // Loop invariants: x4=512B step, x0/x1 are base pointers.
-    // x3 tracks current offset and x5 tracks remaining bytes.
-    subs x5, x2, x3           // remaining = count - offset
-    cmp x5, x4                // remaining < 512?
+    cmp x5, #512
     b.lo copy_cache_loop_cleanup
 
-    // Calculate current src/dst addresses.
-    add x6, x1, x3            // src + offset
-    add x7, x0, x3            // dst + offset
-
-    // First 256B: load then store as 8x pair operations.
+    // First 256B
     ldp q0,  q1,  [x6, #0]
     ldp q2,  q3,  [x6, #32]
     ldp q4,  q5,  [x6, #64]
@@ -74,7 +68,7 @@ copy_cache_loop_start_nt512:  // Main 512B loop
     stnp q20, q21, [x7, #192]
     stnp q22, q23, [x7, #224]
 
-    // Second 256B: reuse registers, keep same memory pattern.
+    // Second 256B
     ldp q24, q25, [x6, #256]
     ldp q26, q27, [x6, #288]
     ldp q28, q29, [x6, #320]
@@ -92,21 +86,16 @@ copy_cache_loop_start_nt512:  // Main 512B loop
     stnp q4,  q5,  [x7, #448]
     stnp q6,  q7,  [x7, #480]
 
-    add x3, x3, x4            // offset += 512
+    add x6, x6, #512
+    add x7, x7, #512
+    sub x5, x5, #512
     b copy_cache_loop_start_nt512
 
 copy_cache_loop_cleanup:      // Tail handling when <512B remain
-    cmp x3, x2
-    b.hs copy_cache_loop_end
-
-    // Recompute remaining and current pointers for tiered tail copy.
-    subs x5, x2, x3
-    add x6, x1, x3
-    add x7, x0, x3
+    cbz x5, copy_cache_loop_end
 
     // 256B chunk
-    cmp x5, #256
-    b.lo copy_cache_cleanup_128
+    tbz x5, #8, copy_cache_cleanup_128
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     ldp q4, q5, [x6, #64]
@@ -128,8 +117,7 @@ copy_cache_loop_cleanup:      // Tail handling when <512B remain
     sub x5, x5, #256
 
 copy_cache_cleanup_128:       // Optional 128B chunk
-    cmp x5, #128
-    b.lo copy_cache_cleanup_64
+    tbz x5, #7, copy_cache_cleanup_64
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     ldp q4, q5, [x6, #64]
@@ -143,8 +131,7 @@ copy_cache_cleanup_128:       // Optional 128B chunk
     sub x5, x5, #128
 
 copy_cache_cleanup_64:        // Optional 64B chunk
-    cmp x5, #64
-    b.lo copy_cache_cleanup_32
+    tbz x5, #6, copy_cache_cleanup_32
     ldp q0, q1, [x6, #0]
     ldp q2, q3, [x6, #32]
     stnp q0, q1, [x7, #0]
@@ -154,20 +141,41 @@ copy_cache_cleanup_64:        // Optional 64B chunk
     sub x5, x5, #64
 
 copy_cache_cleanup_32:        // Optional 32B chunk
-    cmp x5, #32
-    b.lo copy_cache_cleanup_byte
+    tbz x5, #5, copy_cache_cleanup_16
     ldp q0, q1, [x6, #0]
     stnp q0, q1, [x7, #0]
     add x6, x6, #32
     add x7, x7, #32
     sub x5, x5, #32
 
-copy_cache_cleanup_byte:      // Final byte tail (<32B)
-    cbz x5, copy_cache_loop_end
-    ldrb w8, [x6], #1
-    strb w8, [x7], #1
-    subs x5, x5, #1
-    b.ne copy_cache_cleanup_byte
+copy_cache_cleanup_16:        // Optional 16B chunk
+    tbz x5, #4, copy_cache_cleanup_8
+    ldr q0, [x6], #16
+    str q0, [x7], #16
+    sub x5, x5, #16
+
+copy_cache_cleanup_8:         // Optional 8B chunk
+    tbz x5, #3, copy_cache_cleanup_4
+    ldr x8, [x6], #8
+    str x8, [x7], #8
+    sub x5, x5, #8
+
+copy_cache_cleanup_4:         // Optional 4B chunk
+    tbz x5, #2, copy_cache_cleanup_2
+    ldr w8, [x6], #4
+    str w8, [x7], #4
+    sub x5, x5, #4
+
+copy_cache_cleanup_2:         // Optional 2B chunk
+    tbz x5, #1, copy_cache_cleanup_1
+    ldrh w8, [x6], #2
+    strh w8, [x7], #2
+    sub x5, x5, #2
+
+copy_cache_cleanup_1:         // Optional final 1B chunk
+    tbz x5, #0, copy_cache_loop_end
+    ldrb w8, [x6]
+    strb w8, [x7]
 
 copy_cache_loop_end:          // Return to caller
     ret

--- a/src/asm/memory_copy_strided.s
+++ b/src/asm/memory_copy_strided.s
@@ -35,7 +35,7 @@
 // Assumptions / Guarantees:
 //   * Undefined behavior if regions overlap (not a memmove replacement).
 // Implementation Notes:
-//   * Uses modulo arithmetic to wrap around buffer when stride exceeds buffer size.
+//   * Uses branch-based wraparound (offset -= byteCount) to avoid division in hot path.
 //   * Copies 32 bytes (one cache line) per iteration to test strided copy behavior.
 // -----------------------------------------------------------------------------
 
@@ -53,13 +53,9 @@ copy_strided_loop:              // Main strided access loop
     cmp x5, x4              // iteration_count >= num_iterations?
     b.hs copy_strided_done  // If done (unsigned >=), exit
 
-    // Calculate current addresses: src + (offset % byteCount), dst + (offset % byteCount)
-    // Use modulo operation: offset % byteCount = offset - (offset / byteCount) * byteCount
-    // This wraps the offset around when it exceeds buffer size, creating strided pattern.
-    udiv x7, x6, x2         // quotient = offset / byteCount
-    msub x8, x7, x2, x6     // remainder = offset - quotient * byteCount (wraps around)
-    add x9, x1, x8          // src_addr = src + remainder (actual source address)
-    add x10, x0, x8         // dst_addr = dst + remainder (actual destination address)
+    // Calculate current addresses: src + offset, dst + offset
+    add x9, x1, x6          // src_addr = src + offset
+    add x10, x0, x6         // dst_addr = dst + offset
 
     // Load 32 bytes from source
     // Use caller-saved registers q0-q1 only (avoid q8-q15 per AAPCS64).
@@ -71,8 +67,12 @@ copy_strided_loop:              // Main strided access loop
     // encouraging write-combining and reducing cache pollution during bandwidth tests.
     stnp q0, q1, [x10]      // Store pair (32B total, non-temporal) to strided destination
 
-    // Advance offset and iteration count
+    // Advance offset with wraparound (validated path guarantees stride <= byteCount)
     add x6, x6, x3          // offset += stride
+    cmp x6, x2              // offset >= byteCount?
+    b.lo copy_strided_offset_ready
+    sub x6, x6, x2          // offset -= byteCount
+copy_strided_offset_ready:
     add x5, x5, #1          // iteration_count++
     b copy_strided_loop     // Loop again
 

--- a/src/asm/memory_copy_strided_16384.s
+++ b/src/asm/memory_copy_strided_16384.s
@@ -1,0 +1,61 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_copy_strided_16384_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_copy_strided_16384_loop_asm(void* dst,
+//                                                       const void* src,
+//                                                       size_t byteCount,
+//                                                       size_t num_iterations);
+// Purpose:
+//   Copy 32-byte chunks using a fixed 16384-byte stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = src (const void*)
+//   x2 = byteCount (size_t)
+//   x3 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x4-x7, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_copy_strided_16384_loop_asm
+.align 4
+_memory_copy_strided_16384_loop_asm:
+    mov x4, xzr                 // iteration_count = 0
+    mov x5, xzr                 // offset = 0
+
+copy_strided_16384_loop:
+    cmp x4, x3
+    b.hs copy_strided_16384_done
+
+    add x6, x1, x5              // src_addr = src + offset
+    add x7, x0, x5              // dst_addr = dst + offset
+    ldp q0, q1, [x6]            // load 32B
+    stnp q0, q1, [x7]           // store 32B
+
+    add x5, x5, #0x4000         // offset += 16384B stride
+    cmp x5, x2
+    b.lo copy_strided_16384_next
+    sub x5, x5, x2              // wrap
+
+copy_strided_16384_next:
+    add x4, x4, #1
+    b copy_strided_16384_loop
+
+copy_strided_16384_done:
+    ret

--- a/src/asm/memory_copy_strided_2mb.s
+++ b/src/asm/memory_copy_strided_2mb.s
@@ -1,0 +1,61 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_copy_strided_2mb_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_copy_strided_2mb_loop_asm(void* dst,
+//                                                     const void* src,
+//                                                     size_t byteCount,
+//                                                     size_t num_iterations);
+// Purpose:
+//   Copy 32-byte chunks using a fixed 2MB superpage stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = src (const void*)
+//   x2 = byteCount (size_t)
+//   x3 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x4-x7, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_copy_strided_2mb_loop_asm
+.align 4
+_memory_copy_strided_2mb_loop_asm:
+    mov x4, xzr                 // iteration_count = 0
+    mov x5, xzr                 // offset = 0
+
+copy_strided_2mb_loop:
+    cmp x4, x3
+    b.hs copy_strided_2mb_done
+
+    add x6, x1, x5              // src_addr = src + offset
+    add x7, x0, x5              // dst_addr = dst + offset
+    ldp q0, q1, [x6]            // load 32B
+    stnp q0, q1, [x7]           // store 32B
+
+    add x5, x5, #0x200, lsl #12 // offset += 2MB stride
+    cmp x5, x2
+    b.lo copy_strided_2mb_next
+    sub x5, x5, x2              // wrap
+
+copy_strided_2mb_next:
+    add x4, x4, #1
+    b copy_strided_2mb_loop
+
+copy_strided_2mb_done:
+    ret

--- a/src/asm/memory_copy_strided_4096.s
+++ b/src/asm/memory_copy_strided_4096.s
@@ -1,0 +1,61 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_copy_strided_4096_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_copy_strided_4096_loop_asm(void* dst,
+//                                                      const void* src,
+//                                                      size_t byteCount,
+//                                                      size_t num_iterations);
+// Purpose:
+//   Copy 32-byte chunks using a fixed 4096-byte stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = src (const void*)
+//   x2 = byteCount (size_t)
+//   x3 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x4-x7, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_copy_strided_4096_loop_asm
+.align 4
+_memory_copy_strided_4096_loop_asm:
+    mov x4, xzr                 // iteration_count = 0
+    mov x5, xzr                 // offset = 0
+
+copy_strided_4096_loop:
+    cmp x4, x3
+    b.hs copy_strided_4096_done
+
+    add x6, x1, x5              // src_addr = src + offset
+    add x7, x0, x5              // dst_addr = dst + offset
+    ldp q0, q1, [x6]            // load 32B
+    stnp q0, q1, [x7]           // store 32B
+
+    add x5, x5, #0x1000         // offset += 4096B stride
+    cmp x5, x2
+    b.lo copy_strided_4096_next
+    sub x5, x5, x2              // wrap
+
+copy_strided_4096_next:
+    add x4, x4, #1
+    b copy_strided_4096_loop
+
+copy_strided_4096_done:
+    ret

--- a/src/asm/memory_copy_strided_64.s
+++ b/src/asm/memory_copy_strided_64.s
@@ -1,0 +1,61 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_copy_strided_64_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_copy_strided_64_loop_asm(void* dst,
+//                                                    const void* src,
+//                                                    size_t byteCount,
+//                                                    size_t num_iterations);
+// Purpose:
+//   Copy 32-byte chunks using a fixed 64-byte stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = src (const void*)
+//   x2 = byteCount (size_t)
+//   x3 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x4-x7, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_copy_strided_64_loop_asm
+.align 4
+_memory_copy_strided_64_loop_asm:
+    mov x4, xzr                 // iteration_count = 0
+    mov x5, xzr                 // offset = 0
+
+copy_strided_64_loop:
+    cmp x4, x3
+    b.hs copy_strided_64_done
+
+    add x6, x1, x5              // src_addr = src + offset
+    add x7, x0, x5              // dst_addr = dst + offset
+    ldp q0, q1, [x6]            // load 32B
+    stnp q0, q1, [x7]           // store 32B
+
+    add x5, x5, #64             // offset += 64B stride
+    cmp x5, x2
+    b.lo copy_strided_64_next
+    sub x5, x5, x2              // wrap
+
+copy_strided_64_next:
+    add x4, x4, #1
+    b copy_strided_64_loop
+
+copy_strided_64_done:
+    ret

--- a/src/asm/memory_read_cache.s
+++ b/src/asm/memory_read_cache.s
@@ -28,27 +28,34 @@
 //   x0 = 64-bit XOR checksum
 // Clobbers:
 //   x2-x7, x12-x13, q0-q7, q16-q31
+// Implementation Notes:
+//   * Uses pointer+remaining loop state (x6/x5) to avoid per-iteration offset math.
+//   * Processes 512B per iteration (16 pair loads) for high cache-path throughput.
+//   * Distributes XOR into four accumulators (v0-v3) to reduce dependency depth.
+//   * Tail path uses size-bit tests (tbz for 256/128/64/32), then byte cleanup.
 // -----------------------------------------------------------------------------
 
 .global _memory_read_cache_loop_asm
 .align 4
 _memory_read_cache_loop_asm:
-    mov x3, xzr
-    mov x4, #512
+    // x6 = current source pointer, x5 = remaining bytes.
+    // x12 accumulates XOR for byte cleanup (<32B tail).
+    mov x6, x0
+    mov x5, x1
     mov x12, xzr
 
+    // Zero vector accumulators once; they fold all wide reads.
     eor v0.16b, v0.16b, v0.16b
     eor v1.16b, v1.16b, v1.16b
     eor v2.16b, v2.16b, v2.16b
     eor v3.16b, v3.16b, v3.16b
 
-cache_read_loop_start_512:
-    subs x5, x1, x3
-    cmp x5, x4
+cache_read_loop_start_512:    // Main 512B loop
+    // If <512B remain, switch to tail handling.
+    cmp x5, #512
     b.lo cache_read_loop_cleanup
 
-    add x6, x0, x3
-
+    // Load first 256B (8x 32B pairs) using caller-saved SIMD regs.
     ldp q4,  q5,  [x6, #0]
     ldp q6,  q7,  [x6, #32]
     ldp q16, q17, [x6, #64]
@@ -58,6 +65,7 @@ cache_read_loop_start_512:
     ldp q24, q25, [x6, #192]
     ldp q26, q27, [x6, #224]
 
+    // Fold first 256B into four independent accumulators (v0-v3).
     eor v0.16b, v0.16b, v4.16b
     eor v1.16b, v1.16b, v5.16b
     eor v2.16b, v2.16b, v6.16b
@@ -75,6 +83,7 @@ cache_read_loop_start_512:
     eor v2.16b, v2.16b, v26.16b
     eor v3.16b, v3.16b, v27.16b
 
+    // Load second 256B (offsets 256..480).
     ldp q4,  q5,  [x6, #256]
     ldp q6,  q7,  [x6, #288]
     ldp q16, q17, [x6, #320]
@@ -84,6 +93,7 @@ cache_read_loop_start_512:
     ldp q24, q25, [x6, #448]
     ldp q26, q27, [x6, #480]
 
+    // Fold second 256B into the same accumulators.
     eor v0.16b, v0.16b, v4.16b
     eor v1.16b, v1.16b, v5.16b
     eor v2.16b, v2.16b, v6.16b
@@ -101,18 +111,17 @@ cache_read_loop_start_512:
     eor v2.16b, v2.16b, v26.16b
     eor v3.16b, v3.16b, v27.16b
 
-    add x3, x3, x4
+    // Advance pointers/counters for next 512B block.
+    add x6, x6, #512
+    sub x5, x5, #512
     b cache_read_loop_start_512
 
-cache_read_loop_cleanup:
-    cmp x3, x1
-    b.hs cache_read_loop_combine_sum
+cache_read_loop_cleanup:      // Tail handling when <512B remain
+    cbz x5, cache_read_loop_combine_sum
 
-    subs x5, x1, x3
-    add x6, x0, x3
-
-    cmp x5, #256
-    b.lo cache_read_cleanup_128
+    // Tiered tail: check 256/128/64/32 chunks via size bits.
+    tbz x5, #8, cache_read_cleanup_128
+    // 256B chunk: load+fold exactly like half of main loop.
     ldp q4, q5, [x6, #0]
     ldp q6, q7, [x6, #32]
     ldp q16, q17, [x6, #64]
@@ -140,9 +149,8 @@ cache_read_loop_cleanup:
     add x6, x6, #256
     sub x5, x5, #256
 
-cache_read_cleanup_128:
-    cmp x5, #128
-    b.lo cache_read_cleanup_64
+cache_read_cleanup_128:       // Optional 128B chunk
+    tbz x5, #7, cache_read_cleanup_64
     ldp q4, q5, [x6, #0]
     ldp q6, q7, [x6, #32]
     ldp q16, q17, [x6, #64]
@@ -158,9 +166,8 @@ cache_read_cleanup_128:
     add x6, x6, #128
     sub x5, x5, #128
 
-cache_read_cleanup_64:
-    cmp x5, #64
-    b.lo cache_read_cleanup_32
+cache_read_cleanup_64:        // Optional 64B chunk
+    tbz x5, #6, cache_read_cleanup_32
     ldp q4, q5, [x6, #0]
     ldp q6, q7, [x6, #32]
     eor v0.16b, v0.16b, v4.16b
@@ -170,26 +177,28 @@ cache_read_cleanup_64:
     add x6, x6, #64
     sub x5, x5, #64
 
-cache_read_cleanup_32:
-    cmp x5, #32
-    b.lo cache_read_cleanup_byte
+cache_read_cleanup_32:        // Optional 32B chunk
+    tbz x5, #5, cache_read_cleanup_byte
     ldp q4, q5, [x6, #0]
     eor v0.16b, v0.16b, v4.16b
     eor v1.16b, v1.16b, v5.16b
     add x6, x6, #32
     sub x5, x5, #32
 
-cache_read_cleanup_byte:
+cache_read_cleanup_byte:      // Final byte tail (<32B)
+    // Byte tail keeps checksum exact for non-vectorizable remainder.
     cbz x5, cache_read_loop_combine_sum
     ldrb w13, [x6], #1
     eor x12, x12, x13
     subs x5, x5, #1
     b.ne cache_read_cleanup_byte
 
-cache_read_loop_combine_sum:
+cache_read_loop_combine_sum:  // Final reduction and return value
+    // Reduce four vector accumulators into one.
     eor v0.16b, v0.16b, v1.16b
     eor v2.16b, v2.16b, v3.16b
     eor v0.16b, v0.16b, v2.16b
+    // Extract low 64b and fold byte-tail checksum.
     umov x0, v0.d[0]
     eor x0, x0, x12
     ret

--- a/src/asm/memory_read_cache.s
+++ b/src/asm/memory_read_cache.s
@@ -1,0 +1,195 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_read_cache_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" uint64_t memory_read_cache_loop_asm(const void* src, size_t byteCount);
+// Purpose:
+//   Read 'byteCount' bytes from 'src' for cache-bandwidth paths (L1/L2/custom).
+//   This kernel is intentionally independent from main-memory read kernel so cache
+//   tuning can evolve without coupling to DRAM path behavior.
+// Arguments:
+//   x0 = src (const void*)
+//   x1 = byteCount (size_t)
+// Returns:
+//   x0 = 64-bit XOR checksum
+// Clobbers:
+//   x2-x7, x12-x13, q0-q7, q16-q31
+// -----------------------------------------------------------------------------
+
+.global _memory_read_cache_loop_asm
+.align 4
+_memory_read_cache_loop_asm:
+    mov x3, xzr
+    mov x4, #512
+    mov x12, xzr
+
+    eor v0.16b, v0.16b, v0.16b
+    eor v1.16b, v1.16b, v1.16b
+    eor v2.16b, v2.16b, v2.16b
+    eor v3.16b, v3.16b, v3.16b
+
+cache_read_loop_start_512:
+    subs x5, x1, x3
+    cmp x5, x4
+    b.lo cache_read_loop_cleanup
+
+    add x6, x0, x3
+
+    ldp q4,  q5,  [x6, #0]
+    ldp q6,  q7,  [x6, #32]
+    ldp q16, q17, [x6, #64]
+    ldp q18, q19, [x6, #96]
+    ldp q20, q21, [x6, #128]
+    ldp q22, q23, [x6, #160]
+    ldp q24, q25, [x6, #192]
+    ldp q26, q27, [x6, #224]
+
+    eor v0.16b, v0.16b, v4.16b
+    eor v1.16b, v1.16b, v5.16b
+    eor v2.16b, v2.16b, v6.16b
+    eor v3.16b, v3.16b, v7.16b
+    eor v0.16b, v0.16b, v16.16b
+    eor v1.16b, v1.16b, v17.16b
+    eor v2.16b, v2.16b, v18.16b
+    eor v3.16b, v3.16b, v19.16b
+    eor v0.16b, v0.16b, v20.16b
+    eor v1.16b, v1.16b, v21.16b
+    eor v2.16b, v2.16b, v22.16b
+    eor v3.16b, v3.16b, v23.16b
+    eor v0.16b, v0.16b, v24.16b
+    eor v1.16b, v1.16b, v25.16b
+    eor v2.16b, v2.16b, v26.16b
+    eor v3.16b, v3.16b, v27.16b
+
+    ldp q4,  q5,  [x6, #256]
+    ldp q6,  q7,  [x6, #288]
+    ldp q16, q17, [x6, #320]
+    ldp q18, q19, [x6, #352]
+    ldp q20, q21, [x6, #384]
+    ldp q22, q23, [x6, #416]
+    ldp q24, q25, [x6, #448]
+    ldp q26, q27, [x6, #480]
+
+    eor v0.16b, v0.16b, v4.16b
+    eor v1.16b, v1.16b, v5.16b
+    eor v2.16b, v2.16b, v6.16b
+    eor v3.16b, v3.16b, v7.16b
+    eor v0.16b, v0.16b, v16.16b
+    eor v1.16b, v1.16b, v17.16b
+    eor v2.16b, v2.16b, v18.16b
+    eor v3.16b, v3.16b, v19.16b
+    eor v0.16b, v0.16b, v20.16b
+    eor v1.16b, v1.16b, v21.16b
+    eor v2.16b, v2.16b, v22.16b
+    eor v3.16b, v3.16b, v23.16b
+    eor v0.16b, v0.16b, v24.16b
+    eor v1.16b, v1.16b, v25.16b
+    eor v2.16b, v2.16b, v26.16b
+    eor v3.16b, v3.16b, v27.16b
+
+    add x3, x3, x4
+    b cache_read_loop_start_512
+
+cache_read_loop_cleanup:
+    cmp x3, x1
+    b.hs cache_read_loop_combine_sum
+
+    subs x5, x1, x3
+    add x6, x0, x3
+
+    cmp x5, #256
+    b.lo cache_read_cleanup_128
+    ldp q4, q5, [x6, #0]
+    ldp q6, q7, [x6, #32]
+    ldp q16, q17, [x6, #64]
+    ldp q18, q19, [x6, #96]
+    ldp q20, q21, [x6, #128]
+    ldp q22, q23, [x6, #160]
+    ldp q24, q25, [x6, #192]
+    ldp q26, q27, [x6, #224]
+    eor v0.16b, v0.16b, v4.16b
+    eor v1.16b, v1.16b, v5.16b
+    eor v2.16b, v2.16b, v6.16b
+    eor v3.16b, v3.16b, v7.16b
+    eor v0.16b, v0.16b, v16.16b
+    eor v1.16b, v1.16b, v17.16b
+    eor v2.16b, v2.16b, v18.16b
+    eor v3.16b, v3.16b, v19.16b
+    eor v0.16b, v0.16b, v20.16b
+    eor v1.16b, v1.16b, v21.16b
+    eor v2.16b, v2.16b, v22.16b
+    eor v3.16b, v3.16b, v23.16b
+    eor v0.16b, v0.16b, v24.16b
+    eor v1.16b, v1.16b, v25.16b
+    eor v2.16b, v2.16b, v26.16b
+    eor v3.16b, v3.16b, v27.16b
+    add x6, x6, #256
+    sub x5, x5, #256
+
+cache_read_cleanup_128:
+    cmp x5, #128
+    b.lo cache_read_cleanup_64
+    ldp q4, q5, [x6, #0]
+    ldp q6, q7, [x6, #32]
+    ldp q16, q17, [x6, #64]
+    ldp q18, q19, [x6, #96]
+    eor v0.16b, v0.16b, v4.16b
+    eor v1.16b, v1.16b, v5.16b
+    eor v2.16b, v2.16b, v6.16b
+    eor v3.16b, v3.16b, v7.16b
+    eor v0.16b, v0.16b, v16.16b
+    eor v1.16b, v1.16b, v17.16b
+    eor v2.16b, v2.16b, v18.16b
+    eor v3.16b, v3.16b, v19.16b
+    add x6, x6, #128
+    sub x5, x5, #128
+
+cache_read_cleanup_64:
+    cmp x5, #64
+    b.lo cache_read_cleanup_32
+    ldp q4, q5, [x6, #0]
+    ldp q6, q7, [x6, #32]
+    eor v0.16b, v0.16b, v4.16b
+    eor v1.16b, v1.16b, v5.16b
+    eor v2.16b, v2.16b, v6.16b
+    eor v3.16b, v3.16b, v7.16b
+    add x6, x6, #64
+    sub x5, x5, #64
+
+cache_read_cleanup_32:
+    cmp x5, #32
+    b.lo cache_read_cleanup_byte
+    ldp q4, q5, [x6, #0]
+    eor v0.16b, v0.16b, v4.16b
+    eor v1.16b, v1.16b, v5.16b
+    add x6, x6, #32
+    sub x5, x5, #32
+
+cache_read_cleanup_byte:
+    cbz x5, cache_read_loop_combine_sum
+    ldrb w13, [x6], #1
+    eor x12, x12, x13
+    subs x5, x5, #1
+    b.ne cache_read_cleanup_byte
+
+cache_read_loop_combine_sum:
+    eor v0.16b, v0.16b, v1.16b
+    eor v2.16b, v2.16b, v3.16b
+    eor v0.16b, v0.16b, v2.16b
+    umov x0, v0.d[0]
+    eor x0, x0, x12
+    ret

--- a/src/asm/memory_read_cache.s
+++ b/src/asm/memory_read_cache.s
@@ -28,11 +28,16 @@
 //   x0 = 64-bit XOR checksum
 // Clobbers:
 //   x2-x7, x12-x13, q0-q7, q16-q31
+// ABI Notes:
+//   * AAPCS64 callee-saved registers are preserved (x19-x28, v8-v15 untouched).
+//   * Checksum exists to keep loads observable (anti-DCE), not as a data-integrity primitive.
 // Implementation Notes:
 //   * Uses pointer+remaining loop state (x6/x5) to avoid per-iteration offset math.
 //   * Processes 512B per iteration (16 pair loads) for high cache-path throughput.
 //   * Distributes XOR into four accumulators (v0-v3) to reduce dependency depth.
 //   * Tail path uses size-bit tests (tbz for 256/128/64/32), then byte cleanup.
+// Control-Flow Map:
+//   main 512B loop -> tiered tail (256/128/64/32) -> byte tail -> final reduction
 // -----------------------------------------------------------------------------
 
 .global _memory_read_cache_loop_asm
@@ -119,7 +124,8 @@ cache_read_loop_start_512:    // Main 512B loop
 cache_read_loop_cleanup:      // Tail handling when <512B remain
     cbz x5, cache_read_loop_combine_sum
 
-    // Tiered tail: check 256/128/64/32 chunks via size bits.
+    // Tiered tail: bits in x5 encode optional chunks.
+    // bit8=256B, bit7=128B, bit6=64B, bit5=32B.
     tbz x5, #8, cache_read_cleanup_128
     // 256B chunk: load+fold exactly like half of main loop.
     ldp q4, q5, [x6, #0]
@@ -198,7 +204,7 @@ cache_read_loop_combine_sum:  // Final reduction and return value
     eor v0.16b, v0.16b, v1.16b
     eor v2.16b, v2.16b, v3.16b
     eor v0.16b, v0.16b, v2.16b
-    // Extract low 64b and fold byte-tail checksum.
+    // Extract low 64b lane and fold byte-tail checksum (x12) into return value.
     umov x0, v0.d[0]
     eor x0, x0, x12
     ret

--- a/src/asm/memory_read_strided.s
+++ b/src/asm/memory_read_strided.s
@@ -32,7 +32,7 @@
 // Clobbers:
 //   x4‑x8, x12‑x13, q0‑q7, q16‑q31 (data + accumulators, avoiding q8‑q15 per AAPCS64)
 // Implementation Notes:
-//   * Uses modulo arithmetic to wrap around buffer when stride exceeds buffer size.
+//   * Uses branch-based wraparound (offset -= byteCount) to avoid division in hot path.
 //   * Loads 32 bytes (one cache line) per iteration to test strided prefetch behavior.
 //   * Distributes XOR across two accumulators (v0-v1) to reduce dependency depth.
 // -----------------------------------------------------------------------------
@@ -59,12 +59,8 @@ read_strided_loop:              // Main strided access loop
     cmp x4, x3              // iteration_count >= num_iterations?
     b.hs read_strided_combine_sum  // If done (unsigned >=), combine checksums
 
-    // Calculate current address: src + (offset % byteCount)
-    // Use modulo operation: offset % byteCount = offset - (offset / byteCount) * byteCount
-    // This wraps the offset around when it exceeds buffer size, creating strided pattern.
-    udiv x6, x5, x1         // quotient = offset / byteCount
-    msub x7, x6, x1, x5     // remainder = offset - quotient * byteCount (wraps around)
-    add x8, x0, x7          // addr = src + remainder (actual memory address)
+    // Calculate current address: src + offset
+    add x8, x0, x5          // addr = src + offset
 
     // Load 32 bytes (one cache line worth) at strided offset
     // Using caller-saved registers: q2-q3 (avoiding q8-q15 per AAPCS64)
@@ -75,8 +71,12 @@ read_strided_loop:              // Main strided access loop
     eor v0.16b, v0.16b, v2.16b    // Accumulate q2 into v0
     eor v1.16b, v1.16b, v3.16b    // Accumulate q3 into v1
 
-    // Advance offset and iteration count
+    // Advance offset with wraparound (validated path guarantees stride <= byteCount)
     add x5, x5, x2          // offset += stride
+    cmp x5, x1              // offset >= byteCount?
+    b.lo read_strided_offset_ready
+    sub x5, x5, x1          // offset -= byteCount
+read_strided_offset_ready:
     add x4, x4, #1          // iteration_count++
     b read_strided_loop     // Loop again
 

--- a/src/asm/memory_read_strided_16384.s
+++ b/src/asm/memory_read_strided_16384.s
@@ -1,0 +1,67 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_read_strided_16384_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" uint64_t memory_read_strided_16384_loop_asm(const void* src,
+//                                                           size_t byteCount,
+//                                                           size_t num_iterations);
+// Purpose:
+//   Read memory using a fixed 16384-byte stride with wraparound.
+// Arguments:
+//   x0 = src (const void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   x0 = 64-bit XOR checksum
+// Clobbers:
+//   x3-x5, x12-x13, q0-q3 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_read_strided_16384_loop_asm
+.align 4
+_memory_read_strided_16384_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    mov x12, xzr                // checksum low-half scratch
+    mov x13, xzr                // checksum high-half scratch
+    eor v0.16b, v0.16b, v0.16b  // zero accumulator 0
+    eor v1.16b, v1.16b, v1.16b  // zero accumulator 1
+
+read_strided_16384_loop:
+    cmp x3, x2
+    b.hs read_strided_16384_done
+
+    add x5, x0, x4              // addr = src + offset
+    ldp q2, q3, [x5]            // load 32B
+    eor v0.16b, v0.16b, v2.16b
+    eor v1.16b, v1.16b, v3.16b
+
+    add x4, x4, #0x4000         // offset += 16384B stride
+    cmp x4, x1
+    b.lo read_strided_16384_next
+    sub x4, x4, x1              // wrap
+
+read_strided_16384_next:
+    add x3, x3, #1
+    b read_strided_16384_loop
+
+read_strided_16384_done:
+    eor v0.16b, v0.16b, v1.16b
+    umov x12, v0.d[0]
+    umov x13, v0.d[1]
+    eor x0, x12, x13
+    ret

--- a/src/asm/memory_read_strided_2mb.s
+++ b/src/asm/memory_read_strided_2mb.s
@@ -1,0 +1,67 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_read_strided_2mb_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" uint64_t memory_read_strided_2mb_loop_asm(const void* src,
+//                                                         size_t byteCount,
+//                                                         size_t num_iterations);
+// Purpose:
+//   Read memory using a fixed 2MB superpage stride with wraparound.
+// Arguments:
+//   x0 = src (const void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   x0 = 64-bit XOR checksum
+// Clobbers:
+//   x3-x5, x12-x13, q0-q3 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_read_strided_2mb_loop_asm
+.align 4
+_memory_read_strided_2mb_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    mov x12, xzr                // checksum low-half scratch
+    mov x13, xzr                // checksum high-half scratch
+    eor v0.16b, v0.16b, v0.16b  // zero accumulator 0
+    eor v1.16b, v1.16b, v1.16b  // zero accumulator 1
+
+read_strided_2mb_loop:
+    cmp x3, x2
+    b.hs read_strided_2mb_done
+
+    add x5, x0, x4              // addr = src + offset
+    ldp q2, q3, [x5]            // load 32B
+    eor v0.16b, v0.16b, v2.16b
+    eor v1.16b, v1.16b, v3.16b
+
+    add x4, x4, #0x200, lsl #12 // offset += 2MB stride
+    cmp x4, x1
+    b.lo read_strided_2mb_next
+    sub x4, x4, x1              // wrap
+
+read_strided_2mb_next:
+    add x3, x3, #1
+    b read_strided_2mb_loop
+
+read_strided_2mb_done:
+    eor v0.16b, v0.16b, v1.16b
+    umov x12, v0.d[0]
+    umov x13, v0.d[1]
+    eor x0, x12, x13
+    ret

--- a/src/asm/memory_read_strided_4096.s
+++ b/src/asm/memory_read_strided_4096.s
@@ -1,0 +1,68 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_read_strided_4096_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" uint64_t memory_read_strided_4096_loop_asm(const void* src,
+//                                                          size_t byteCount,
+//                                                          size_t num_iterations);
+// Purpose:
+//   Read memory using a fixed 4096-byte (page) stride with wraparound.
+//   Accumulates an XOR checksum over 32-byte loads.
+// Arguments:
+//   x0 = src (const void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   x0 = 64-bit XOR checksum
+// Clobbers:
+//   x3-x5, x12-x13, q0-q3 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_read_strided_4096_loop_asm
+.align 4
+_memory_read_strided_4096_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    mov x12, xzr                // checksum low-half scratch
+    mov x13, xzr                // checksum high-half scratch
+    eor v0.16b, v0.16b, v0.16b  // zero accumulator 0
+    eor v1.16b, v1.16b, v1.16b  // zero accumulator 1
+
+read_strided_4096_loop:
+    cmp x3, x2
+    b.hs read_strided_4096_done
+
+    add x5, x0, x4              // addr = src + offset
+    ldp q2, q3, [x5]            // load 32B
+    eor v0.16b, v0.16b, v2.16b
+    eor v1.16b, v1.16b, v3.16b
+
+    add x4, x4, #0x1000         // offset += 4096B stride
+    cmp x4, x1
+    b.lo read_strided_4096_next
+    sub x4, x4, x1              // wrap
+
+read_strided_4096_next:
+    add x3, x3, #1
+    b read_strided_4096_loop
+
+read_strided_4096_done:
+    eor v0.16b, v0.16b, v1.16b
+    umov x12, v0.d[0]
+    umov x13, v0.d[1]
+    eor x0, x12, x13
+    ret

--- a/src/asm/memory_read_strided_64.s
+++ b/src/asm/memory_read_strided_64.s
@@ -1,0 +1,72 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_read_strided_64_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" uint64_t memory_read_strided_64_loop_asm(const void* src,
+//                                                        size_t byteCount,
+//                                                        size_t num_iterations);
+// Purpose:
+//   Read memory using a fixed 64-byte stride with wraparound addressing.
+//   Accumulates an XOR checksum across all 32-byte loads to keep accesses
+//   architecturally visible.
+// Arguments:
+//   x0 = src (const void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   x0 = 64-bit XOR checksum
+// Clobbers:
+//   x3-x5, x12-x13, q0-q3 (caller-saved only)
+// Implementation Notes:
+//   * Fixed stride immediate avoids passing/decoding a dynamic stride.
+//   * Wraparound uses compare/subtract (no divide/modulo in hot loop).
+// -----------------------------------------------------------------------------
+
+.global _memory_read_strided_64_loop_asm
+.align 4
+_memory_read_strided_64_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    mov x12, xzr                // checksum low-half scratch
+    mov x13, xzr                // checksum high-half scratch
+    eor v0.16b, v0.16b, v0.16b  // zero accumulator 0
+    eor v1.16b, v1.16b, v1.16b  // zero accumulator 1
+
+read_strided_64_loop:
+    cmp x3, x2                  // iteration_count >= num_iterations?
+    b.hs read_strided_64_done
+
+    add x5, x0, x4              // addr = src + offset
+    ldp q2, q3, [x5]            // load 32B at current strided address
+    eor v0.16b, v0.16b, v2.16b  // fold first 16B
+    eor v1.16b, v1.16b, v3.16b  // fold second 16B
+
+    add x4, x4, #64             // offset += 64B stride
+    cmp x4, x1                  // wrapped past byteCount?
+    b.lo read_strided_64_next
+    sub x4, x4, x1              // offset -= byteCount (single-wrap)
+
+read_strided_64_next:
+    add x3, x3, #1              // iteration_count++
+    b read_strided_64_loop
+
+read_strided_64_done:
+    eor v0.16b, v0.16b, v1.16b  // combine vector accumulators
+    umov x12, v0.d[0]           // extract low 64 bits
+    umov x13, v0.d[1]           // extract high 64 bits
+    eor x0, x12, x13            // collapse to final checksum
+    ret

--- a/src/asm/memory_write_cache.s
+++ b/src/asm/memory_write_cache.s
@@ -1,0 +1,142 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_write_cache_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_write_cache_loop_asm(void* dst, size_t byteCount);
+// Purpose:
+//   Write 'byteCount' bytes of zeros to 'dst' for cache-bandwidth paths (L1/L2/custom).
+//   This kernel is intentionally independent from main-memory write kernel so cache
+//   tuning can evolve without coupling to DRAM path behavior.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = byteCount (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x3-x7, q0-q7, q16-q31 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_write_cache_loop_asm
+.align 4
+_memory_write_cache_loop_asm:
+    mov x3, xzr
+    mov x4, #512
+
+    movi v0.16b, #0
+    movi v1.16b, #0
+    movi v2.16b, #0
+    movi v3.16b, #0
+    movi v4.16b, #0
+    movi v5.16b, #0
+    movi v6.16b, #0
+    movi v7.16b, #0
+    movi v16.16b, #0
+    movi v17.16b, #0
+    movi v18.16b, #0
+    movi v19.16b, #0
+    movi v20.16b, #0
+    movi v21.16b, #0
+    movi v22.16b, #0
+    movi v23.16b, #0
+    movi v24.16b, #0
+    movi v25.16b, #0
+    movi v26.16b, #0
+    movi v27.16b, #0
+    movi v28.16b, #0
+    movi v29.16b, #0
+    movi v30.16b, #0
+    movi v31.16b, #0
+
+write_cache_loop_start_nt512:
+    subs x5, x1, x3
+    cmp x5, x4
+    b.lo write_cache_loop_cleanup
+
+    add x7, x0, x3
+    stnp q0,  q1,  [x7, #0]
+    stnp q2,  q3,  [x7, #32]
+    stnp q4,  q5,  [x7, #64]
+    stnp q6,  q7,  [x7, #96]
+    stnp q16, q17, [x7, #128]
+    stnp q18, q19, [x7, #160]
+    stnp q20, q21, [x7, #192]
+    stnp q22, q23, [x7, #224]
+    stnp q24, q25, [x7, #256]
+    stnp q26, q27, [x7, #288]
+    stnp q28, q29, [x7, #320]
+    stnp q30, q31, [x7, #352]
+    stnp q0,  q1,  [x7, #384]
+    stnp q2,  q3,  [x7, #416]
+    stnp q4,  q5,  [x7, #448]
+    stnp q6,  q7,  [x7, #480]
+
+    add x3, x3, x4
+    b write_cache_loop_start_nt512
+
+write_cache_loop_cleanup:
+    cmp x3, x1
+    b.hs write_cache_loop_end
+
+    subs x5, x1, x3
+    add x7, x0, x3
+
+    cmp x5, #256
+    b.lo write_cache_cleanup_128
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    stnp q4, q5, [x7, #64]
+    stnp q6, q7, [x7, #96]
+    stnp q16, q17, [x7, #128]
+    stnp q18, q19, [x7, #160]
+    stnp q20, q21, [x7, #192]
+    stnp q22, q23, [x7, #224]
+    add x7, x7, #256
+    sub x5, x5, #256
+
+write_cache_cleanup_128:
+    cmp x5, #128
+    b.lo write_cache_cleanup_64
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    stnp q4, q5, [x7, #64]
+    stnp q6, q7, [x7, #96]
+    add x7, x7, #128
+    sub x5, x5, #128
+
+write_cache_cleanup_64:
+    cmp x5, #64
+    b.lo write_cache_cleanup_32
+    stnp q0, q1, [x7, #0]
+    stnp q2, q3, [x7, #32]
+    add x7, x7, #64
+    sub x5, x5, #64
+
+write_cache_cleanup_32:
+    cmp x5, #32
+    b.lo write_cache_cleanup_byte
+    stnp q0, q1, [x7, #0]
+    add x7, x7, #32
+    sub x5, x5, #32
+
+write_cache_cleanup_byte:
+    cbz x5, write_cache_loop_end
+    strb wzr, [x7], #1
+    subs x5, x5, #1
+    b.ne write_cache_cleanup_byte
+
+write_cache_loop_end:
+    ret

--- a/src/asm/memory_write_cache.s
+++ b/src/asm/memory_write_cache.s
@@ -28,115 +28,112 @@
 //   (none)
 // Clobbers:
 //   x3-x7, q0-q7, q16-q31 (caller-saved only)
+// Implementation Notes:
+//   * Uses one zero vector (q0) and repeats it for all wide stores.
+//   * Uses pointer+remaining loop state (x7/x5) for lower loop-control overhead.
+//   * Processes 512B per iteration using 16 store pairs.
+//   * Tail uses size-bit tests plus 16/8/4/2/1 scalar zero stores.
 // -----------------------------------------------------------------------------
 
 .global _memory_write_cache_loop_asm
 .align 4
 _memory_write_cache_loop_asm:
-    mov x3, xzr
-    mov x4, #512
-
+    // x7 = current dst pointer, x5 = remaining bytes.
+    mov x7, x0
+    mov x5, x1
+    // Materialize zero vector once and reuse for all SIMD stores.
     movi v0.16b, #0
-    movi v1.16b, #0
-    movi v2.16b, #0
-    movi v3.16b, #0
-    movi v4.16b, #0
-    movi v5.16b, #0
-    movi v6.16b, #0
-    movi v7.16b, #0
-    movi v16.16b, #0
-    movi v17.16b, #0
-    movi v18.16b, #0
-    movi v19.16b, #0
-    movi v20.16b, #0
-    movi v21.16b, #0
-    movi v22.16b, #0
-    movi v23.16b, #0
-    movi v24.16b, #0
-    movi v25.16b, #0
-    movi v26.16b, #0
-    movi v27.16b, #0
-    movi v28.16b, #0
-    movi v29.16b, #0
-    movi v30.16b, #0
-    movi v31.16b, #0
 
-write_cache_loop_start_nt512:
-    subs x5, x1, x3
-    cmp x5, x4
+write_cache_loop_start_nt512: // Main 512B loop
+    // If <512B remain, switch to tail handling.
+    cmp x5, #512
     b.lo write_cache_loop_cleanup
 
-    add x7, x0, x3
-    stnp q0,  q1,  [x7, #0]
-    stnp q2,  q3,  [x7, #32]
-    stnp q4,  q5,  [x7, #64]
-    stnp q6,  q7,  [x7, #96]
-    stnp q16, q17, [x7, #128]
-    stnp q18, q19, [x7, #160]
-    stnp q20, q21, [x7, #192]
-    stnp q22, q23, [x7, #224]
-    stnp q24, q25, [x7, #256]
-    stnp q26, q27, [x7, #288]
-    stnp q28, q29, [x7, #320]
-    stnp q30, q31, [x7, #352]
-    stnp q0,  q1,  [x7, #384]
-    stnp q2,  q3,  [x7, #416]
-    stnp q4,  q5,  [x7, #448]
-    stnp q6,  q7,  [x7, #480]
+    // 512B of zero stores (16x 32B store pairs).
+    stp q0, q0, [x7, #0]
+    stp q0, q0, [x7, #32]
+    stp q0, q0, [x7, #64]
+    stp q0, q0, [x7, #96]
+    stp q0, q0, [x7, #128]
+    stp q0, q0, [x7, #160]
+    stp q0, q0, [x7, #192]
+    stp q0, q0, [x7, #224]
+    stp q0, q0, [x7, #256]
+    stp q0, q0, [x7, #288]
+    stp q0, q0, [x7, #320]
+    stp q0, q0, [x7, #352]
+    stp q0, q0, [x7, #384]
+    stp q0, q0, [x7, #416]
+    stp q0, q0, [x7, #448]
+    stp q0, q0, [x7, #480]
 
-    add x3, x3, x4
+    // Advance destination and remaining-byte count.
+    add x7, x7, #512
+    sub x5, x5, #512
     b write_cache_loop_start_nt512
 
-write_cache_loop_cleanup:
-    cmp x3, x1
-    b.hs write_cache_loop_end
+write_cache_loop_cleanup:     // Tail handling when <512B remain
+    cbz x5, write_cache_loop_end
 
-    subs x5, x1, x3
-    add x7, x0, x3
-
-    cmp x5, #256
-    b.lo write_cache_cleanup_128
-    stnp q0, q1, [x7, #0]
-    stnp q2, q3, [x7, #32]
-    stnp q4, q5, [x7, #64]
-    stnp q6, q7, [x7, #96]
-    stnp q16, q17, [x7, #128]
-    stnp q18, q19, [x7, #160]
-    stnp q20, q21, [x7, #192]
-    stnp q22, q23, [x7, #224]
+    // Tiered tail: test size bits for 256/128/64/32 before scalar ladder.
+    tbz x5, #8, write_cache_cleanup_128
+    // 256B chunk
+    stp q0, q0, [x7, #0]
+    stp q0, q0, [x7, #32]
+    stp q0, q0, [x7, #64]
+    stp q0, q0, [x7, #96]
+    stp q0, q0, [x7, #128]
+    stp q0, q0, [x7, #160]
+    stp q0, q0, [x7, #192]
+    stp q0, q0, [x7, #224]
     add x7, x7, #256
     sub x5, x5, #256
 
-write_cache_cleanup_128:
-    cmp x5, #128
-    b.lo write_cache_cleanup_64
-    stnp q0, q1, [x7, #0]
-    stnp q2, q3, [x7, #32]
-    stnp q4, q5, [x7, #64]
-    stnp q6, q7, [x7, #96]
+write_cache_cleanup_128:      // Optional 128B chunk
+    tbz x5, #7, write_cache_cleanup_64
+    stp q0, q0, [x7, #0]
+    stp q0, q0, [x7, #32]
+    stp q0, q0, [x7, #64]
+    stp q0, q0, [x7, #96]
     add x7, x7, #128
     sub x5, x5, #128
 
-write_cache_cleanup_64:
-    cmp x5, #64
-    b.lo write_cache_cleanup_32
-    stnp q0, q1, [x7, #0]
-    stnp q2, q3, [x7, #32]
+write_cache_cleanup_64:       // Optional 64B chunk
+    tbz x5, #6, write_cache_cleanup_32
+    stp q0, q0, [x7, #0]
+    stp q0, q0, [x7, #32]
     add x7, x7, #64
     sub x5, x5, #64
 
-write_cache_cleanup_32:
-    cmp x5, #32
-    b.lo write_cache_cleanup_byte
-    stnp q0, q1, [x7, #0]
+write_cache_cleanup_32:       // Optional 32B chunk
+    tbz x5, #5, write_cache_cleanup_16
+    stp q0, q0, [x7, #0]
     add x7, x7, #32
     sub x5, x5, #32
 
-write_cache_cleanup_byte:
-    cbz x5, write_cache_loop_end
-    strb wzr, [x7], #1
-    subs x5, x5, #1
-    b.ne write_cache_cleanup_byte
+write_cache_cleanup_16:       // Optional 16B scalar zero store
+    tbz x5, #4, write_cache_cleanup_8
+    str q0, [x7], #16
+    sub x5, x5, #16
 
-write_cache_loop_end:
+write_cache_cleanup_8:        // Optional 8B scalar zero store
+    tbz x5, #3, write_cache_cleanup_4
+    str xzr, [x7], #8
+    sub x5, x5, #8
+
+write_cache_cleanup_4:        // Optional 4B scalar zero store
+    tbz x5, #2, write_cache_cleanup_2
+    str wzr, [x7], #4
+    sub x5, x5, #4
+
+write_cache_cleanup_2:        // Optional 2B scalar zero store
+    tbz x5, #1, write_cache_cleanup_1
+    strh wzr, [x7], #2
+    sub x5, x5, #2
+
+write_cache_cleanup_1:        // Optional final 1B zero store
+    tbz x5, #0, write_cache_loop_end
+    strb wzr, [x7]
+
+write_cache_loop_end:         // Return to caller
     ret

--- a/src/asm/memory_write_cache.s
+++ b/src/asm/memory_write_cache.s
@@ -28,11 +28,16 @@
 //   (none)
 // Clobbers:
 //   x3-x7, q0-q7, q16-q31 (caller-saved only)
+// ABI Notes:
+//   * AAPCS64 callee-saved registers are preserved (x19-x28, v8-v15 untouched).
+//   * Caller is expected to provide writable range [dst, dst + byteCount).
 // Implementation Notes:
 //   * Uses one zero vector (q0) and repeats it for all wide stores.
 //   * Uses pointer+remaining loop state (x7/x5) for lower loop-control overhead.
 //   * Processes 512B per iteration using 16 store pairs.
 //   * Tail uses size-bit tests plus 16/8/4/2/1 scalar zero stores.
+// Control-Flow Map:
+//   main 512B loop -> tiered tail (256/128/64/32) -> scalar tail -> return
 // -----------------------------------------------------------------------------
 
 .global _memory_write_cache_loop_asm
@@ -75,7 +80,8 @@ write_cache_loop_start_nt512: // Main 512B loop
 write_cache_loop_cleanup:     // Tail handling when <512B remain
     cbz x5, write_cache_loop_end
 
-    // Tiered tail: test size bits for 256/128/64/32 before scalar ladder.
+    // Tiered tail: bits in x5 encode presence of each power-of-two chunk.
+    // bit8=256B, bit7=128B, bit6=64B, bit5=32B.
     tbz x5, #8, write_cache_cleanup_128
     // 256B chunk
     stp q0, q0, [x7, #0]

--- a/src/asm/memory_write_strided.s
+++ b/src/asm/memory_write_strided.s
@@ -32,7 +32,7 @@
 // Clobbers:
 //   x4‑x8, q0‑q1 (zero vectors, avoiding q8‑q15 per AAPCS64)
 // Implementation Notes:
-//   * Uses modulo arithmetic to wrap around buffer when stride exceeds buffer size.
+//   * Uses branch-based wraparound (offset -= byteCount) to avoid division in hot path.
 //   * Stores 32 bytes (one cache line) per iteration to test strided write behavior.
 //   * Zero vectors are materialized once (movi) then reused.
 // -----------------------------------------------------------------------------
@@ -58,20 +58,20 @@ write_strided_loop:              // Main strided access loop
     cmp x4, x3              // iteration_count >= num_iterations?
     b.hs write_strided_done // If done (unsigned >=), exit
 
-    // Calculate current address: dst + (offset % byteCount)
-    // Use modulo operation: offset % byteCount = offset - (offset / byteCount) * byteCount
-    // This wraps the offset around when it exceeds buffer size, creating strided pattern.
-    udiv x6, x5, x1         // quotient = offset / byteCount
-    msub x7, x6, x1, x5     // remainder = offset - quotient * byteCount (wraps around)
-    add x8, x0, x7          // addr = dst + remainder (actual memory address)
+    // Calculate current address: dst + offset
+    add x8, x0, x5          // addr = dst + offset
 
     // Store 32 bytes (one cache line worth) at strided offset
     // Non-temporal stores (stnp) hint to CPU that data won't be reused soon,
     // encouraging write-combining and reducing cache pollution during bandwidth tests.
     stnp q0, q1, [x8]       // Store pair (32B total, non-temporal) to strided address
 
-    // Advance offset and iteration count
+    // Advance offset with wraparound (validated path guarantees stride <= byteCount)
     add x5, x5, x2          // offset += stride
+    cmp x5, x1              // offset >= byteCount?
+    b.lo write_strided_offset_ready
+    sub x5, x5, x1          // offset -= byteCount
+write_strided_offset_ready:
     add x4, x4, #1          // iteration_count++
     b write_strided_loop    // Loop again
 

--- a/src/asm/memory_write_strided_16384.s
+++ b/src/asm/memory_write_strided_16384.s
@@ -1,0 +1,59 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_write_strided_16384_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_write_strided_16384_loop_asm(void* dst,
+//                                                        size_t byteCount,
+//                                                        size_t num_iterations);
+// Purpose:
+//   Write zeros using a fixed 16384-byte stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x3-x5, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_write_strided_16384_loop_asm
+.align 4
+_memory_write_strided_16384_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    movi v0.16b, #0             // zero vector 0
+    movi v1.16b, #0             // zero vector 1
+
+write_strided_16384_loop:
+    cmp x3, x2
+    b.hs write_strided_16384_done
+
+    add x5, x0, x4              // addr = dst + offset
+    stnp q0, q1, [x5]           // store 32B
+
+    add x4, x4, #0x4000         // offset += 16384B stride
+    cmp x4, x1
+    b.lo write_strided_16384_next
+    sub x4, x4, x1              // wrap
+
+write_strided_16384_next:
+    add x3, x3, #1
+    b write_strided_16384_loop
+
+write_strided_16384_done:
+    ret

--- a/src/asm/memory_write_strided_2mb.s
+++ b/src/asm/memory_write_strided_2mb.s
@@ -1,0 +1,59 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_write_strided_2mb_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_write_strided_2mb_loop_asm(void* dst,
+//                                                      size_t byteCount,
+//                                                      size_t num_iterations);
+// Purpose:
+//   Write zeros using a fixed 2MB superpage stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x3-x5, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_write_strided_2mb_loop_asm
+.align 4
+_memory_write_strided_2mb_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    movi v0.16b, #0             // zero vector 0
+    movi v1.16b, #0             // zero vector 1
+
+write_strided_2mb_loop:
+    cmp x3, x2
+    b.hs write_strided_2mb_done
+
+    add x5, x0, x4              // addr = dst + offset
+    stnp q0, q1, [x5]           // store 32B
+
+    add x4, x4, #0x200, lsl #12 // offset += 2MB stride
+    cmp x4, x1
+    b.lo write_strided_2mb_next
+    sub x4, x4, x1              // wrap
+
+write_strided_2mb_next:
+    add x3, x3, #1
+    b write_strided_2mb_loop
+
+write_strided_2mb_done:
+    ret

--- a/src/asm/memory_write_strided_4096.s
+++ b/src/asm/memory_write_strided_4096.s
@@ -1,0 +1,59 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_write_strided_4096_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_write_strided_4096_loop_asm(void* dst,
+//                                                       size_t byteCount,
+//                                                       size_t num_iterations);
+// Purpose:
+//   Write zeros using a fixed 4096-byte (page) stride with wraparound.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x3-x5, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_write_strided_4096_loop_asm
+.align 4
+_memory_write_strided_4096_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    movi v0.16b, #0             // zero vector 0
+    movi v1.16b, #0             // zero vector 1
+
+write_strided_4096_loop:
+    cmp x3, x2
+    b.hs write_strided_4096_done
+
+    add x5, x0, x4              // addr = dst + offset
+    stnp q0, q1, [x5]           // store 32B
+
+    add x4, x4, #0x1000         // offset += 4096B stride
+    cmp x4, x1
+    b.lo write_strided_4096_next
+    sub x4, x4, x1              // wrap
+
+write_strided_4096_next:
+    add x3, x3, #1
+    b write_strided_4096_loop
+
+write_strided_4096_done:
+    ret

--- a/src/asm/memory_write_strided_64.s
+++ b/src/asm/memory_write_strided_64.s
@@ -1,0 +1,59 @@
+// Copyright 2026 Timo Heimonen <timo.heimonen@proton.me>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+// memory_write_strided_64_loop_asm
+// -----------------------------------------------------------------------------
+// C++ Prototype:
+//   extern "C" void memory_write_strided_64_loop_asm(void* dst,
+//                                                     size_t byteCount,
+//                                                     size_t num_iterations);
+// Purpose:
+//   Write zeros using a fixed 64-byte stride and wraparound addressing.
+// Arguments:
+//   x0 = dst (void*)
+//   x1 = byteCount (size_t)
+//   x2 = num_iterations (size_t)
+// Returns:
+//   (none)
+// Clobbers:
+//   x3-x5, q0-q1 (caller-saved only)
+// -----------------------------------------------------------------------------
+
+.global _memory_write_strided_64_loop_asm
+.align 4
+_memory_write_strided_64_loop_asm:
+    mov x3, xzr                 // iteration_count = 0
+    mov x4, xzr                 // offset = 0
+    movi v0.16b, #0             // zero vector 0
+    movi v1.16b, #0             // zero vector 1
+
+write_strided_64_loop:
+    cmp x3, x2
+    b.hs write_strided_64_done
+
+    add x5, x0, x4              // addr = dst + offset
+    stnp q0, q1, [x5]           // store 32B
+
+    add x4, x4, #64             // offset += 64B stride
+    cmp x4, x1
+    b.lo write_strided_64_next
+    sub x4, x4, x1              // wrap
+
+write_strided_64_next:
+    add x3, x3, #1
+    b write_strided_64_loop
+
+write_strided_64_done:
+    ret

--- a/src/benchmark/bandwidth_tests.cpp
+++ b/src/benchmark/bandwidth_tests.cpp
@@ -37,6 +37,62 @@
 #include "asm/asm_functions.h"  // Assembly function declarations
 #include "benchmark/parallel_test_framework.h"
 
+namespace {
+
+double run_read_test_impl(void* buffer,
+                          size_t size,
+                          int iterations,
+                          int num_threads,
+                          std::atomic<uint64_t>& checksum,
+                          HighResTimer& timer,
+                          uint64_t (*read_func)(const void*, size_t)) {
+  checksum.store(0, std::memory_order_relaxed);
+
+  auto read_work = [&checksum, read_func](char* chunk_start, size_t chunk_size, int iters) {
+    uint64_t local_checksum = 0;
+    for (int i = 0; i < iters; ++i) {
+      uint64_t thread_checksum = read_func(chunk_start, chunk_size);
+      local_checksum ^= thread_checksum;
+    }
+    checksum.fetch_xor(local_checksum, std::memory_order_release);
+  };
+
+  return run_parallel_test(buffer, size, iterations, num_threads, timer, read_work, "read");
+}
+
+double run_write_test_impl(void* buffer,
+                           size_t size,
+                           int iterations,
+                           int num_threads,
+                           HighResTimer& timer,
+                           void (*write_func)(void*, size_t)) {
+  auto write_work = [write_func](char* chunk_start, size_t chunk_size, int iters) {
+    for (int i = 0; i < iters; ++i) {
+      write_func(chunk_start, chunk_size);
+    }
+  };
+
+  return run_parallel_test(buffer, size, iterations, num_threads, timer, write_work, "write");
+}
+
+double run_copy_test_impl(void* dst,
+                          void* src,
+                          size_t size,
+                          int iterations,
+                          int num_threads,
+                          HighResTimer& timer,
+                          void (*copy_func)(void*, const void*, size_t)) {
+  auto copy_work = [copy_func](char* dst_chunk, char* src_chunk, size_t chunk_size, int iters) {
+    for (int i = 0; i < iters; ++i) {
+      copy_func(dst_chunk, src_chunk, chunk_size);
+    }
+  };
+
+  return run_parallel_test_copy(dst, src, size, iterations, num_threads, timer, copy_work, "copy");
+}
+
+}  // namespace
+
 /**
  * @brief Executes the multi-threaded read bandwidth benchmark.
  *
@@ -70,32 +126,17 @@
  */
 double run_read_test(void *buffer, size_t size, int iterations, int num_threads, std::atomic<uint64_t> &checksum,
                      HighResTimer &timer) {
-  // Initialize checksum to 0 before measurement pass (thread-safe atomic assignment)
-  checksum.store(0, std::memory_order_relaxed);
-  
-  // Define the work function for read operations
-  // Alignment is now handled in the framework, so we receive aligned chunk_start directly
-  auto read_work = [&checksum](char *chunk_start, size_t chunk_size, int iters) {
-    // Accumulate checksum locally to avoid atomic operations in the inner loop.
-    // This reduces contention and improves performance in multi-threaded scenarios.
-    uint64_t local_checksum = 0;
-    for (int i = 0; i < iters; ++i) {
-      // Call external assembly function for reading.
-      uint64_t thread_checksum = memory_read_loop_asm(chunk_start, chunk_size);
-      // Combine result locally (non-atomic). XOR is commutative and associative,
-      // so the order of combination doesn't matter for checksum correctness.
-      local_checksum ^= thread_checksum;
-    }
-    // Atomically combine final result (one atomic per thread).
-    // Using release memory order ensures:
-    // 1. All previous operations in this thread are visible before the checksum update
-    // 2. The checksum update is properly synchronized with thread completion
-    // 3. XOR is commutative and associative, so order doesn't matter for correctness
-    // 4. Each thread accumulates locally first, reducing contention
-    checksum.fetch_xor(local_checksum, std::memory_order_release);
-  };
-  
-  return run_parallel_test(buffer, size, iterations, num_threads, timer, read_work, "read");
+  return run_read_test_impl(buffer, size, iterations, num_threads, checksum, timer, memory_read_loop_asm);
+}
+
+double run_read_test_with_kernel(void* buffer,
+                                 size_t size,
+                                 int iterations,
+                                 int num_threads,
+                                 std::atomic<uint64_t>& checksum,
+                                 HighResTimer& timer,
+                                 uint64_t (*read_func)(const void*, size_t)) {
+  return run_read_test_impl(buffer, size, iterations, num_threads, checksum, timer, read_func);
 }
 
 /**
@@ -127,15 +168,16 @@ double run_read_test(void *buffer, size_t size, int iterations, int num_threads,
  * @see memory_write_loop_asm() for the low-level write implementation
  */
 double run_write_test(void *buffer, size_t size, int iterations, int num_threads, HighResTimer &timer) {
-  // Define the work function for write operations
-  // Alignment is now handled in the framework, so we receive aligned chunk_start directly
-  auto write_work = [](char *chunk_start, size_t chunk_size, int iters) {
-    for (int i = 0; i < iters; ++i) {
-      memory_write_loop_asm(chunk_start, chunk_size);
-    }
-  };
-  
-  return run_parallel_test(buffer, size, iterations, num_threads, timer, write_work, "write");
+  return run_write_test_impl(buffer, size, iterations, num_threads, timer, memory_write_loop_asm);
+}
+
+double run_write_test_with_kernel(void* buffer,
+                                  size_t size,
+                                  int iterations,
+                                  int num_threads,
+                                  HighResTimer& timer,
+                                  void (*write_func)(void*, size_t)) {
+  return run_write_test_impl(buffer, size, iterations, num_threads, timer, write_func);
 }
 
 /**
@@ -173,15 +215,15 @@ double run_write_test(void *buffer, size_t size, int iterations, int num_threads
  * @see memory_copy_loop_asm() for the low-level copy implementation
  */
 double run_copy_test(void *dst, void *src, size_t size, int iterations, int num_threads, HighResTimer &timer) {
-  // Define the work function for copy operations
-  // Alignment and src/dst correspondence are now handled in the framework,
-  // so we receive aligned chunk pointers directly
-  auto copy_work = [](char *dst_chunk, char *src_chunk, size_t chunk_size, int iters) {
-    for (int i = 0; i < iters; ++i) {
-      memory_copy_loop_asm(dst_chunk, src_chunk, chunk_size);
-    }
-  };
-  
-  return run_parallel_test_copy(dst, src, size, iterations, num_threads, timer, copy_work, "copy");
+  return run_copy_test_impl(dst, src, size, iterations, num_threads, timer, memory_copy_loop_asm);
 }
 
+double run_copy_test_with_kernel(void* dst,
+                                 void* src,
+                                 size_t size,
+                                 int iterations,
+                                 int num_threads,
+                                 HighResTimer& timer,
+                                 void (*copy_func)(void*, const void*, size_t)) {
+  return run_copy_test_impl(dst, src, size, iterations, num_threads, timer, copy_func);
+}

--- a/src/benchmark/benchmark_executor.cpp
+++ b/src/benchmark/benchmark_executor.cpp
@@ -352,21 +352,24 @@ void run_main_memory_bandwidth_tests(const BenchmarkBuffers& buffers, const Benc
  */
 void run_single_cache_bandwidth_test(void* src_buffer, void* dst_buffer, size_t buffer_size,
                                      int cache_iterations, int num_threads, HighResTimer& test_timer,
+                                     uint64_t (*read_kernel)(const void*, size_t),
+                                     void (*write_kernel)(void*, size_t),
+                                     void (*copy_kernel)(void*, const void*, size_t),
                                      double& read_time, double& write_time, double& copy_time,
                                      std::atomic<uint64_t>& read_checksum) {
   show_progress();
   std::atomic<uint64_t> warmup_read_checksum{0};
   warmup_cache_read(src_buffer, buffer_size, num_threads, warmup_read_checksum);
-  read_time = run_read_test(src_buffer, buffer_size, cache_iterations, 
-                           num_threads, read_checksum, test_timer);
+  read_time = run_read_test_with_kernel(src_buffer, buffer_size, cache_iterations,
+                                        num_threads, read_checksum, test_timer, read_kernel);
   
   warmup_cache_write(dst_buffer, buffer_size, num_threads);
-  write_time = run_write_test(dst_buffer, buffer_size, cache_iterations, 
-                             num_threads, test_timer);
+  write_time = run_write_test_with_kernel(dst_buffer, buffer_size, cache_iterations,
+                                          num_threads, test_timer, write_kernel);
   
   warmup_cache_copy(dst_buffer, src_buffer, buffer_size, num_threads);
-  copy_time = run_copy_test(dst_buffer, src_buffer, buffer_size, 
-                           cache_iterations, num_threads, test_timer);
+  copy_time = run_copy_test_with_kernel(dst_buffer, src_buffer, buffer_size,
+                                        cache_iterations, num_threads, test_timer, copy_kernel);
 }
 
 /**
@@ -398,11 +401,15 @@ void run_cache_bandwidth_tests(const BenchmarkBuffers& buffers, const BenchmarkC
   int cache_iterations = calculate_cache_iterations_saturated(config.iterations);
   // Use user-specified threads if set, otherwise default to single-threaded for cache tests
   int cache_threads = config.user_specified_threads ? config.num_threads : Constants::SINGLE_THREAD;
+  auto cache_read_kernel = memory_read_cache_loop_asm;
+  auto cache_write_kernel = memory_write_cache_loop_asm;
+  auto cache_copy_kernel = memory_copy_cache_loop_asm;
   
   if (config.use_custom_cache_size) {
     if (config.custom_buffer_size > 0 && buffers.custom_bw_src() != nullptr && buffers.custom_bw_dst() != nullptr) {
       run_single_cache_bandwidth_test(buffers.custom_bw_src(), buffers.custom_bw_dst(), config.custom_buffer_size,
                                       cache_iterations, cache_threads, test_timer,
+                                      cache_read_kernel, cache_write_kernel, cache_copy_kernel,
                                       timings.custom_read_time, timings.custom_write_time, timings.custom_copy_time,
                                       timings.custom_read_checksum);
     }
@@ -410,6 +417,7 @@ void run_cache_bandwidth_tests(const BenchmarkBuffers& buffers, const BenchmarkC
     if (config.l1_buffer_size > 0 && buffers.l1_bw_src() != nullptr && buffers.l1_bw_dst() != nullptr) {
       run_single_cache_bandwidth_test(buffers.l1_bw_src(), buffers.l1_bw_dst(), config.l1_buffer_size,
                                       cache_iterations, cache_threads, test_timer,
+                                      cache_read_kernel, cache_write_kernel, cache_copy_kernel,
                                       timings.l1_read_time, timings.l1_write_time, timings.l1_copy_time,
                                       timings.l1_read_checksum);
     }
@@ -417,6 +425,7 @@ void run_cache_bandwidth_tests(const BenchmarkBuffers& buffers, const BenchmarkC
     if (config.l2_buffer_size > 0 && buffers.l2_bw_src() != nullptr && buffers.l2_bw_dst() != nullptr) {
       run_single_cache_bandwidth_test(buffers.l2_bw_src(), buffers.l2_bw_dst(), config.l2_buffer_size,
                                       cache_iterations, cache_threads, test_timer,
+                                      cache_read_kernel, cache_write_kernel, cache_copy_kernel,
                                       timings.l2_read_time, timings.l2_write_time, timings.l2_copy_time,
                                       timings.l2_read_checksum);
     }

--- a/src/benchmark/benchmark_tests.h
+++ b/src/benchmark/benchmark_tests.h
@@ -47,6 +47,25 @@ struct HighResTimer;
 double run_read_test(void* buffer, size_t size, int iterations, int num_threads, std::atomic<uint64_t>& checksum, HighResTimer& timer);
 
 /**
+ * @brief Run read benchmark test with a specific assembly read kernel
+ * @param buffer Pointer to buffer to read from
+ * @param size Size of buffer in bytes
+ * @param iterations Number of iterations to run
+ * @param num_threads Number of threads to use
+ * @param checksum Reference to atomic checksum accumulator
+ * @param timer Reference to high-resolution timer
+ * @param read_func Assembly read kernel to invoke
+ * @return Total elapsed time in seconds
+ */
+double run_read_test_with_kernel(void* buffer,
+                                 size_t size,
+                                 int iterations,
+                                 int num_threads,
+                                 std::atomic<uint64_t>& checksum,
+                                 HighResTimer& timer,
+                                 uint64_t (*read_func)(const void*, size_t));
+
+/**
  * @brief Run write benchmark test
  * @param buffer Pointer to buffer to write to
  * @param size Size of buffer in bytes
@@ -56,6 +75,23 @@ double run_read_test(void* buffer, size_t size, int iterations, int num_threads,
  * @return Total elapsed time in seconds
  */
 double run_write_test(void* buffer, size_t size, int iterations, int num_threads, HighResTimer& timer);
+
+/**
+ * @brief Run write benchmark test with a specific assembly write kernel
+ * @param buffer Pointer to buffer to write to
+ * @param size Size of buffer in bytes
+ * @param iterations Number of iterations to run
+ * @param num_threads Number of threads to use
+ * @param timer Reference to high-resolution timer
+ * @param write_func Assembly write kernel to invoke
+ * @return Total elapsed time in seconds
+ */
+double run_write_test_with_kernel(void* buffer,
+                                  size_t size,
+                                  int iterations,
+                                  int num_threads,
+                                  HighResTimer& timer,
+                                  void (*write_func)(void*, size_t));
 
 /**
  * @brief Run copy benchmark test
@@ -68,6 +104,25 @@ double run_write_test(void* buffer, size_t size, int iterations, int num_threads
  * @return Total elapsed time in seconds
  */
 double run_copy_test(void* dst, void* src, size_t size, int iterations, int num_threads, HighResTimer& timer);
+
+/**
+ * @brief Run copy benchmark test with a specific assembly copy kernel
+ * @param dst Pointer to destination buffer
+ * @param src Pointer to source buffer
+ * @param size Size of buffers in bytes
+ * @param iterations Number of iterations to run
+ * @param num_threads Number of threads to use
+ * @param timer Reference to high-resolution timer
+ * @param copy_func Assembly copy kernel to invoke
+ * @return Total elapsed time in seconds
+ */
+double run_copy_test_with_kernel(void* dst,
+                                 void* src,
+                                 size_t size,
+                                 int iterations,
+                                 int num_threads,
+                                 HighResTimer& timer,
+                                 void (*copy_func)(void*, const void*, size_t));
 
 /**
  * @brief Run latency benchmark test
@@ -93,4 +148,3 @@ double run_latency_test(void* buffer, size_t num_accesses, HighResTimer& timer, 
 double run_cache_latency_test(void* buffer, size_t buffer_size, size_t num_accesses, HighResTimer& timer, std::vector<double>* latency_samples = nullptr, int sample_count = 0);
 
 #endif // BENCHMARK_TESTS_H
-

--- a/src/core/config/constants.h
+++ b/src/core/config/constants.h
@@ -141,7 +141,7 @@ namespace Constants {
   constexpr size_t PATTERN_STRIDE_PAGE = 4096;  // Page stride (bytes)
   constexpr size_t PATTERN_STRIDE_PAGE_16K = 16 * 1024;  // Apple Silicon page-size stride candidate (bytes)
   constexpr size_t PATTERN_STRIDE_SUPERPAGE_2MB = 2 * 1024 * 1024;  // Large-page stride candidate (bytes)
-  constexpr int PATTERN_STRIDED_2MB_ITERATIONS_MULTIPLIER = 15;  // Extra iteration scaling for 2MB-stride stability
+  constexpr size_t PATTERN_STRIDED_MIN_TOUCHED_BYTES = 256 * 1024 * 1024;  // Minimum touched bytes target for strided pattern stability
   constexpr size_t PATTERN_RANDOM_ACCESS_MIN = 1000;  // Minimum number of random accesses
   constexpr size_t PATTERN_RANDOM_ACCESS_MAX = 1000000;  // Maximum number of random accesses
   constexpr size_t PATTERN_WARMUP_INDICES_MAX = 10000;  // Maximum indices to use for warmup

--- a/src/core/config/constants.h
+++ b/src/core/config/constants.h
@@ -141,6 +141,7 @@ namespace Constants {
   constexpr size_t PATTERN_STRIDE_PAGE = 4096;  // Page stride (bytes)
   constexpr size_t PATTERN_STRIDE_PAGE_16K = 16 * 1024;  // Apple Silicon page-size stride candidate (bytes)
   constexpr size_t PATTERN_STRIDE_SUPERPAGE_2MB = 2 * 1024 * 1024;  // Large-page stride candidate (bytes)
+  constexpr int PATTERN_STRIDED_2MB_ITERATIONS_MULTIPLIER = 15;  // Extra iteration scaling for 2MB-stride stability
   constexpr size_t PATTERN_RANDOM_ACCESS_MIN = 1000;  // Minimum number of random accesses
   constexpr size_t PATTERN_RANDOM_ACCESS_MAX = 1000000;  // Maximum number of random accesses
   constexpr size_t PATTERN_WARMUP_INDICES_MAX = 10000;  // Maximum indices to use for warmup

--- a/src/core/config/version.h
+++ b/src/core/config/version.h
@@ -29,6 +29,6 @@
  * @def SOFTVERSION
  * @brief Software version number (semantic versioning format as string)
  */
-#define SOFTVERSION "0.53.9"
+#define SOFTVERSION "0.54.0"
 
 #endif // VERSION_H

--- a/src/pattern_benchmark/execution_strided.cpp
+++ b/src/pattern_benchmark/execution_strided.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <atomic>
 #include <cstdlib>
+#include <algorithm>
 #include <limits>
 
 // Forward declarations from helpers.cpp
@@ -90,27 +91,24 @@ static bool calculate_strided_params(size_t buffer_size, size_t stride,
   return true;
 }
 
-static int calculate_effective_iterations_for_stride(size_t stride, int base_iterations) {
+static int calculate_effective_iterations_for_stride(size_t actual_data_accessed, int base_iterations) {
   using namespace Constants;
 
-  if (base_iterations <= 0) {
+  if (base_iterations <= 0 || actual_data_accessed == 0) {
     return 0;
   }
 
-  if (stride != PATTERN_STRIDE_SUPERPAGE_2MB) {
-    return base_iterations;
-  }
+  size_t required_iterations =
+      PATTERN_STRIDED_MIN_TOUCHED_BYTES / actual_data_accessed +
+      ((PATTERN_STRIDED_MIN_TOUCHED_BYTES % actual_data_accessed) != 0 ? 1 : 0);
+  size_t effective_iterations =
+      std::max(static_cast<size_t>(base_iterations), required_iterations);
 
-  const int multiplier = PATTERN_STRIDED_2MB_ITERATIONS_MULTIPLIER;
-  if (multiplier <= 1) {
-    return base_iterations;
-  }
-
-  if (base_iterations > (std::numeric_limits<int>::max() / multiplier)) {
+  if (effective_iterations > static_cast<size_t>(std::numeric_limits<int>::max())) {
     return std::numeric_limits<int>::max();
   }
 
-  return base_iterations * multiplier;
+  return static_cast<int>(effective_iterations);
 }
 
 // ============================================================================
@@ -145,7 +143,7 @@ int run_strided_pattern_benchmarks(const BenchmarkBuffers& buffers, const Benchm
     return EXIT_SUCCESS;
   }
 
-  const int effective_iterations = calculate_effective_iterations_for_stride(stride, config.iterations);
+  const int effective_iterations = calculate_effective_iterations_for_stride(actual_data_accessed, config.iterations);
   if (effective_iterations <= 0) {
     return EXIT_SUCCESS;
   }

--- a/src/pattern_benchmark/execution_strided.cpp
+++ b/src/pattern_benchmark/execution_strided.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <atomic>
 #include <cstdlib>
+#include <limits>
 
 // Forward declarations from helpers.cpp
 double run_pattern_read_strided_test(void* buffer, size_t size, size_t stride, int iterations,
@@ -59,9 +60,9 @@ double calculate_bandwidth(size_t data_size, int iterations, double elapsed_time
 
 // Calculate effective buffer size for strided pattern
 static bool calculate_strided_params(size_t buffer_size, size_t stride, 
-                                      size_t& effective_buffer_size, 
-                                      size_t& num_iterations, 
-                                      size_t& actual_data_accessed) {
+                                       size_t& effective_buffer_size, 
+                                       size_t& num_iterations, 
+                                       size_t& actual_data_accessed) {
   using namespace Constants;
   
   // The strided assembly functions use modulo arithmetic: addr = base + (offset % byteCount)
@@ -89,6 +90,29 @@ static bool calculate_strided_params(size_t buffer_size, size_t stride,
   return true;
 }
 
+static int calculate_effective_iterations_for_stride(size_t stride, int base_iterations) {
+  using namespace Constants;
+
+  if (base_iterations <= 0) {
+    return 0;
+  }
+
+  if (stride != PATTERN_STRIDE_SUPERPAGE_2MB) {
+    return base_iterations;
+  }
+
+  const int multiplier = PATTERN_STRIDED_2MB_ITERATIONS_MULTIPLIER;
+  if (multiplier <= 1) {
+    return base_iterations;
+  }
+
+  if (base_iterations > (std::numeric_limits<int>::max() / multiplier)) {
+    return std::numeric_limits<int>::max();
+  }
+
+  return base_iterations * multiplier;
+}
+
 // ============================================================================
 // Strided Pattern Execution Functions
 // ============================================================================
@@ -96,8 +120,8 @@ static bool calculate_strided_params(size_t buffer_size, size_t stride,
 // Run strided pattern benchmarks (access with specified stride)
 // Returns EXIT_SUCCESS on success, EXIT_FAILURE on error, or skips pattern if buffer too small
 int run_strided_pattern_benchmarks(const BenchmarkBuffers& buffers, const BenchmarkConfig& config,
-                                     size_t stride, double& read_bw, double& write_bw, double& copy_bw,
-                                     HighResTimer& timer) {
+                                      size_t stride, double& read_bw, double& write_bw, double& copy_bw,
+                                      HighResTimer& timer) {
   using namespace Constants;
   
   // Initialize results to 0 in case we skip this pattern
@@ -120,31 +144,36 @@ int run_strided_pattern_benchmarks(const BenchmarkBuffers& buffers, const Benchm
     // Buffer too small for this stride - skip pattern (not an error)
     return EXIT_SUCCESS;
   }
+
+  const int effective_iterations = calculate_effective_iterations_for_stride(stride, config.iterations);
+  if (effective_iterations <= 0) {
+    return EXIT_SUCCESS;
+  }
   
   // Execute read benchmark
   show_progress();
   std::atomic<uint64_t> checksum{0};
   warmup_read_strided(buffers.src_buffer(), effective_buffer_size, stride, config.num_threads, checksum);
   double read_time = run_pattern_read_strided_test(buffers.src_buffer(), effective_buffer_size, stride,
-                                                     config.iterations, checksum, timer, config.num_threads);
-  read_bw = calculate_bandwidth(actual_data_accessed, config.iterations, read_time);
+                                                     effective_iterations, checksum, timer, config.num_threads);
+  read_bw = calculate_bandwidth(actual_data_accessed, effective_iterations, read_time);
 
   // Execute write benchmark
   show_progress();
   warmup_write_strided(buffers.dst_buffer(), effective_buffer_size, stride, config.num_threads);
   double write_time = run_pattern_write_strided_test(buffers.dst_buffer(), effective_buffer_size, stride,
-                                                      config.iterations, timer, config.num_threads);
-  write_bw = calculate_bandwidth(actual_data_accessed, config.iterations, write_time);
+                                                       effective_iterations, timer, config.num_threads);
+  write_bw = calculate_bandwidth(actual_data_accessed, effective_iterations, write_time);
 
   // Execute copy benchmark
   show_progress();
   warmup_copy_strided(buffers.dst_buffer(), buffers.src_buffer(), effective_buffer_size, stride, config.num_threads);
   double copy_time = run_pattern_copy_strided_test(buffers.dst_buffer(), buffers.src_buffer(),
-                                                    effective_buffer_size, stride, config.iterations, timer,
-                                                    config.num_threads);
+                                                     effective_buffer_size, stride, effective_iterations, timer,
+                                                     config.num_threads);
   // For copy: actual_data_accessed bytes are read + actual_data_accessed bytes are written per iteration
   copy_bw = calculate_bandwidth(actual_data_accessed * Constants::COPY_OPERATION_MULTIPLIER,
-                                config.iterations, copy_time);
+                                effective_iterations, copy_time);
   
   return EXIT_SUCCESS;
 }

--- a/src/pattern_benchmark/helpers.cpp
+++ b/src/pattern_benchmark/helpers.cpp
@@ -71,6 +71,77 @@ inline void build_random_chunk_indices(const std::vector<size_t>& indices,
   }
 }
 
+inline uint64_t run_strided_read_kernel(const void* src,
+                                        size_t byte_count,
+                                        size_t stride,
+                                        size_t num_iterations) {
+  using namespace Constants;
+
+  switch (stride) {
+    case PATTERN_STRIDE_CACHE_LINE:
+      return memory_read_strided_64_loop_asm(src, byte_count, num_iterations);
+    case PATTERN_STRIDE_PAGE:
+      return memory_read_strided_4096_loop_asm(src, byte_count, num_iterations);
+    case PATTERN_STRIDE_PAGE_16K:
+      return memory_read_strided_16384_loop_asm(src, byte_count, num_iterations);
+    case PATTERN_STRIDE_SUPERPAGE_2MB:
+      return memory_read_strided_2mb_loop_asm(src, byte_count, num_iterations);
+    default:
+      return memory_read_strided_loop_asm(src, byte_count, stride, num_iterations);
+  }
+}
+
+inline void run_strided_write_kernel(void* dst,
+                                     size_t byte_count,
+                                     size_t stride,
+                                     size_t num_iterations) {
+  using namespace Constants;
+
+  switch (stride) {
+    case PATTERN_STRIDE_CACHE_LINE:
+      memory_write_strided_64_loop_asm(dst, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE:
+      memory_write_strided_4096_loop_asm(dst, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE_16K:
+      memory_write_strided_16384_loop_asm(dst, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_SUPERPAGE_2MB:
+      memory_write_strided_2mb_loop_asm(dst, byte_count, num_iterations);
+      return;
+    default:
+      memory_write_strided_loop_asm(dst, byte_count, stride, num_iterations);
+      return;
+  }
+}
+
+inline void run_strided_copy_kernel(void* dst,
+                                    const void* src,
+                                    size_t byte_count,
+                                    size_t stride,
+                                    size_t num_iterations) {
+  using namespace Constants;
+
+  switch (stride) {
+    case PATTERN_STRIDE_CACHE_LINE:
+      memory_copy_strided_64_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE:
+      memory_copy_strided_4096_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE_16K:
+      memory_copy_strided_16384_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_SUPERPAGE_2MB:
+      memory_copy_strided_2mb_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    default:
+      memory_copy_strided_loop_asm(dst, src, byte_count, stride, num_iterations);
+      return;
+  }
+}
+
 }  // namespace
 
 // Helper function to run a pattern read test (multi-threaded)
@@ -139,7 +210,7 @@ double run_pattern_read_strided_test(void* buffer, size_t size, size_t stride, i
     }
 
     for (int i = 0; i < iters; ++i) {
-      uint64_t result = memory_read_strided_loop_asm(chunk_start, effective_size, stride, num_accesses);
+      uint64_t result = run_strided_read_kernel(chunk_start, effective_size, stride, num_accesses);
       local_checksum ^= result;
     }
     checksum.fetch_xor(local_checksum, std::memory_order_release);
@@ -162,7 +233,7 @@ double run_pattern_write_strided_test(void* buffer, size_t size, size_t stride, 
     }
 
     for (int i = 0; i < iters; ++i) {
-      memory_write_strided_loop_asm(chunk_start, effective_size, stride, num_accesses);
+      run_strided_write_kernel(chunk_start, effective_size, stride, num_accesses);
     }
   };
 
@@ -183,7 +254,7 @@ double run_pattern_copy_strided_test(void* dst, void* src, size_t size, size_t s
     }
 
     for (int i = 0; i < iters; ++i) {
-      memory_copy_strided_loop_asm(dst_chunk, src_chunk, effective_size, stride, num_accesses);
+      run_strided_copy_kernel(dst_chunk, src_chunk, effective_size, stride, num_accesses);
     }
   };
 

--- a/src/warmup/cache_warmup.cpp
+++ b/src/warmup/cache_warmup.cpp
@@ -57,7 +57,11 @@ void warmup_cache_write(void* dst_buffer, size_t size, int num_threads) {
     return;
   }
   size_t warmup_size = size;
-  warmup_parallel(dst_buffer, size, num_threads, warmup_write_chunk_op, true, nullptr, nullptr, warmup_size);
+  auto cache_write_chunk_op = [](char* chunk_start, char* /* src_chunk */, size_t chunk_size,
+                                 std::atomic<uint64_t>* /* checksum */) {
+    memory_write_cache_loop_asm(chunk_start, chunk_size);
+  };
+  warmup_parallel(dst_buffer, size, num_threads, cache_write_chunk_op, true, nullptr, nullptr, warmup_size);
 }
 
 /**
@@ -77,5 +81,9 @@ void warmup_cache_copy(void* dst, void* src, size_t size, int num_threads) {
     return;
   }
   size_t warmup_size = size;
-  warmup_parallel(dst, size, num_threads, warmup_copy_chunk_op, true, src, nullptr, warmup_size);
+  auto cache_copy_chunk_op = [](char* dst_chunk, char* src_chunk, size_t chunk_size,
+                                std::atomic<uint64_t>* /* checksum */) {
+    memory_copy_cache_loop_asm(dst_chunk, src_chunk, chunk_size);
+  };
+  warmup_parallel(dst, size, num_threads, cache_copy_chunk_op, true, src, nullptr, warmup_size);
 }

--- a/src/warmup/pattern_warmup.cpp
+++ b/src/warmup/pattern_warmup.cpp
@@ -31,6 +31,7 @@
 #include "output/console/messages/messages_api.h"   // For error and warning messages
 #include "warmup/warmup.h"
 #include "warmup/warmup_internal.h"
+#include "core/config/constants.h"
 
 namespace {
 
@@ -64,6 +65,77 @@ bool validate_random_warmup_indices(const std::vector<size_t>& indices) {
   }
 
   return true;
+}
+
+uint64_t run_strided_read_warmup_kernel(const void* src,
+                                        size_t byte_count,
+                                        size_t stride,
+                                        size_t num_iterations) {
+  using namespace Constants;
+
+  switch (stride) {
+    case PATTERN_STRIDE_CACHE_LINE:
+      return memory_read_strided_64_loop_asm(src, byte_count, num_iterations);
+    case PATTERN_STRIDE_PAGE:
+      return memory_read_strided_4096_loop_asm(src, byte_count, num_iterations);
+    case PATTERN_STRIDE_PAGE_16K:
+      return memory_read_strided_16384_loop_asm(src, byte_count, num_iterations);
+    case PATTERN_STRIDE_SUPERPAGE_2MB:
+      return memory_read_strided_2mb_loop_asm(src, byte_count, num_iterations);
+    default:
+      return memory_read_strided_loop_asm(src, byte_count, stride, num_iterations);
+  }
+}
+
+void run_strided_write_warmup_kernel(void* dst,
+                                     size_t byte_count,
+                                     size_t stride,
+                                     size_t num_iterations) {
+  using namespace Constants;
+
+  switch (stride) {
+    case PATTERN_STRIDE_CACHE_LINE:
+      memory_write_strided_64_loop_asm(dst, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE:
+      memory_write_strided_4096_loop_asm(dst, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE_16K:
+      memory_write_strided_16384_loop_asm(dst, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_SUPERPAGE_2MB:
+      memory_write_strided_2mb_loop_asm(dst, byte_count, num_iterations);
+      return;
+    default:
+      memory_write_strided_loop_asm(dst, byte_count, stride, num_iterations);
+      return;
+  }
+}
+
+void run_strided_copy_warmup_kernel(void* dst,
+                                    const void* src,
+                                    size_t byte_count,
+                                    size_t stride,
+                                    size_t num_iterations) {
+  using namespace Constants;
+
+  switch (stride) {
+    case PATTERN_STRIDE_CACHE_LINE:
+      memory_copy_strided_64_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE:
+      memory_copy_strided_4096_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_PAGE_16K:
+      memory_copy_strided_16384_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    case PATTERN_STRIDE_SUPERPAGE_2MB:
+      memory_copy_strided_2mb_loop_asm(dst, src, byte_count, num_iterations);
+      return;
+    default:
+      memory_copy_strided_loop_asm(dst, src, byte_count, stride, num_iterations);
+      return;
+  }
 }
 
 template<typename RandomOp>
@@ -135,7 +207,7 @@ void warmup_read_strided(void* buffer, size_t size, size_t stride, int num_threa
                                  std::atomic<uint64_t>* checksum) {
     // Use strided read for warmup
     size_t num_iterations = (chunk_size + stride - 1) / stride;
-    uint64_t result = memory_read_strided_loop_asm(chunk_start, chunk_size, stride, num_iterations);
+    uint64_t result = run_strided_read_warmup_kernel(chunk_start, chunk_size, stride, num_iterations);
     if (checksum) {
       checksum->fetch_xor(result, std::memory_order_release);
     }
@@ -161,7 +233,7 @@ void warmup_write_strided(void* buffer, size_t size, size_t stride, int num_thre
                                   std::atomic<uint64_t>* /* checksum */) {
     // Use strided write for warmup
     size_t num_iterations = (chunk_size + stride - 1) / stride;
-    memory_write_strided_loop_asm(chunk_start, chunk_size, stride, num_iterations);
+    run_strided_write_warmup_kernel(chunk_start, chunk_size, stride, num_iterations);
   };
   warmup_parallel(buffer, size, num_threads, write_chunk_op, true, nullptr, nullptr, warmup_size);
 }
@@ -185,7 +257,7 @@ void warmup_copy_strided(void* dst, void* src, size_t size, size_t stride, int n
                                  std::atomic<uint64_t>* /* checksum */) {
     // Use strided copy for warmup
     size_t num_iterations = (chunk_size + stride - 1) / stride;
-    memory_copy_strided_loop_asm(dst_chunk, src_chunk, chunk_size, stride, num_iterations);
+    run_strided_copy_warmup_kernel(dst_chunk, src_chunk, chunk_size, stride, num_iterations);
   };
   warmup_parallel(dst, size, num_threads, copy_chunk_op, true, src, nullptr, warmup_size);
 }


### PR DESCRIPTION
## [0.54.0] - 2026-03-19

Changes in benchmark ASM kernels.
From this version onwards bandwidth results are not compatible against older(<0.54.0) version results.
Latency kernels unchanged.

### Changed
  - Main change: split pattern ASM kernels into separate files for each case (main-memory, cache, forward, reverse, strided, random).
  - Some kernels currently behave the same, but they are intentionally kept separate to make future tuning easier.
  - Tuned cache ASM kernels with pointer+remaining loop state and bit-test based tail handling.
  - Pattern strided benchmarks now scale effective iterations so each stride variant targets at least `256 MB` of touched data (for more stable results on small buffers).
  - Added `PATTERN_STRIDED_MIN_TOUCHED_BYTES` constant (`256 * 1024 * 1024`) for strided pattern iteration scaling.
  - Simplified and improved inline comments in cache ASM kernels:
    - `src/asm/memory_write_cache.s`
    - `src/asm/memory_read_cache.s`
    - `src/asm/memory_copy_cache.s`
  - Added clearer ABI/register-preservation notes, tail-bit (`tbz`) mapping notes, and short control-flow maps for easier future tuning.