### PR TITLE
Version 0.55.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.55.1] - 2026-X-X
+## [0.55.1] - 2026-04-06
 
 ### Fixed
-  - help example shown incorrectly 'Example: memory_benchmark -iterations 2000 -buffersize 1024 -output results.json', fixed to 'Example: memory_benchmark -benchmark -iterations 2000 -buffersize 1024 -output results.json'
+  - **Help example missing `-benchmark` flag**: Fixed help example that showed `memory_benchmark -iterations 2000 -buffersize 1024 -output results.json` instead of the correct `memory_benchmark -benchmark -iterations 2000 -buffersize 1024 -output results.json`.
 
 ## [0.55.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.55.1] - 2026-X-X
+
+### Fixed
+  - help example shown incorrectly 'Example: memory_benchmark -iterations 2000 -buffersize 1024 -output results.json', fixed to 'Example: memory_benchmark -benchmark -iterations 2000 -buffersize 1024 -output results.json'
+
 ## [0.55.0] - 2026-04-05
 
 ### Changed

--- a/src/core/config/version.h
+++ b/src/core/config/version.h
@@ -29,6 +29,6 @@
  * @def SOFTVERSION
  * @brief Software version number (semantic versioning format as string)
  */
-#define SOFTVERSION "0.55.0"
+#define SOFTVERSION "0.55.1"
 
 #endif // VERSION_H

--- a/src/output/console/messages/program_messages.cpp
+++ b/src/output/console/messages/program_messages.cpp
@@ -154,7 +154,7 @@ std::string usage_options(const std::string& prog_name) {
 
 std::string usage_example(const std::string& prog_name) {
   std::ostringstream oss;
-  oss << "Example: " << prog_name << " -iterations 2000 -buffersize 1024 -output results.json\n";
+  oss << "Example: " << prog_name << " -benchmark -iterations 2000 -buffersize 1024 -output results.json\n";
   return oss.str();
 }
 


### PR DESCRIPTION
This is just small fix for help texts.

## [0.55.1] - 2026-04-06

### Fixed
  - **Help example missing `-benchmark` flag**: Fixed help example that showed `memory_benchmark -iterations 2000 -buffersize 1024 -output results.json` instead of the correct `memory_benchmark -benchmark -iterations 2000 -buffersize 1024 -output results.json`.